### PR TITLE
cubeit-installer: cleanup container tarballs

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -678,6 +678,8 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	elif [ -e /${IMAGESDIR}/config.smart ]; then
 	    cp /${IMAGESDIR}/config.smart ${TMPMNT}/var/lib/lxc/$cname/rootfs/var/lib/smart/config
 	fi
+
+	rm ${TMPMNT}/tmp/$(basename $c)
     done
 
     # install and modify services


### PR DESCRIPTION
As we install each container we create a copy of the container tarball
to ${TMPMNT}/tmp. Depending on how many containers we install this can
cause the partition to run out of space. Since we don't use these
tarballs after the container is installed we can do some cleanup after
we install each container to avoid space issues.

Signed-off-by: Mark Asselstine mark.asselstine@windriver.com
