### PR TITLE
Minor updates to allow things to work with WR Linux

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -180,6 +180,10 @@ if ! [ -n "$DISTRIBUTION" ]; then
     DISTRIBUTION="OverC"
 fi
 
+if [ -v CONTAINER_PREFIX -a -n $CONTAINER_PREFIX ] ; then
+    export CNAME_PREFIX="--prefix $CONTAINER_PREFIX"
+fi
+
 get_container_name_by_prop()
 {
     local prop=$1
@@ -394,7 +398,7 @@ mount /dev/${fs_dev}1 ./boot
 
 img=`ls boot/*Image-* 2> /dev/null`
 if [ -n "$img" ] ; then
-	debugmsg ${DEBUG_INFO} "[INFO]: installing initramfs"
+	debugmsg ${DEBUG_INFO} "[INFO]: installing initramfs ($INSTALL_INITRAMFS)"
 	kernel=`basename boot/*Image-*`
 	kernel_version=`echo $kernel | sed 's/^[^0-9]*-//g'`
 	initrd="initrd-${kernel_version}.gz"
@@ -591,7 +595,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
     # determine if we need tell overc-cctl to use bridged networking or not.
     overc_cctl_bridged_net_opt=" -b "
     for c in `strip_properties ${HDINSTALL_CONTAINERS}`; do
-	cname=`${SBINDIR}/cubename $c`
+	cname=`${SBINDIR}/cubename $CNAME_PREFIX $c`
 	net_offset=`get_prop_value_by_container $cname "net"`
 	if [ -n "$net_offset" ] && [ $net_offset -eq 1 ]; then
 	    overc_cctl_bridged_net_opt=" "
@@ -629,7 +633,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 
 	# containers names are "prefix-<container name>-<... suffixes >
 	container_src=`basename $c`
-	cname=`${SBINDIR}/cubename $c`
+	cname=`${SBINDIR}/cubename $CNAME_PREFIX $c`
 	cp $c ${TMPMNT}/tmp/
 	cp ${SBINDIR}/overc-cctl ${TMPMNT}/tmp/
 	
@@ -719,7 +723,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
     # install and modify services
     for c in `strip_properties ${HDINSTALL_CONTAINERS}`; do
 	container_src=`basename $c`
-	cname=`${SBINDIR}/cubename $c`
+	cname=`${SBINDIR}/cubename $CNAME_PREFIX $c`
 
 	# if there was a foreground container defined (attribte 'active' on a vty), then we
 	# install a chvt service to make sure it is in the foreground after boot. Note, this

--- a/sbin/cubename
+++ b/sbin/cubename
@@ -13,12 +13,15 @@ usage()
 {
 cat << EOF
 
-  cubename <path to cube file>
+  cubename [--prefix <prefix>] <path to cube file>
 
   example:
     
       $  cubename cube-server-genericx86-64-20151030174740.rootfs.tar.bz2
  
+  options:
+      --prefix: specify an arbitrary prefix which is found in front of the
+                container filename
 EOF
 }
 
@@ -52,8 +55,9 @@ function extract_container_name
 
     # container names follow these rules:
     #
-    # <type>-<name>-<rest>
+    # [<prefix>]<type>-<name>-<rest>
     #
+    # <prefix>: optional filename prefix
     # <type>: cube, docker, lxc
     # <name>: dom or <string>
     # 
@@ -69,6 +73,10 @@ function extract_container_name
     # 
 
     container_src=`basename $fullname`
+
+    if [ -v prefix -a -n "$prefix" ]; then
+	container_src=$(echo $container_src | sed "s/^${prefix}//")
+    fi
 
     # read in the parts, split by '-'. keys start with 0 and increase
     array=(${container_src//\-/ }) 

--- a/sbin/cubename
+++ b/sbin/cubename
@@ -95,6 +95,13 @@ function extract_container_name
 	esac
     fi
 
+    # Wind River Linux produces container image names
+    # where type == "container", thus:
+    # <prefix>container-<name>-<rest>
+    if [ "$type" = "container" ]; then
+	output=$type-$name
+    fi
+
     echo ${output}
 }
 

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -763,7 +763,7 @@ create_property_map()
 
 	cn=`echo "${c}" | cut -d':' -f1`
 	cn_short=`basename ${cn}`
-	cname=`${SBINDIR}/cubename $cn_short`
+	cname=`${SBINDIR}/cubename $CNAME_PREFIX $cn_short`
 
 	all_props=""
 	for prop_count in 1 2 3 4 5 6; do


### PR DESCRIPTION
Wind River Linux produces image names with prefixes. This functionality was planned for but not implemented. Added the implementation and a way to specify a prefix, if needed. If no prefix exists the workflow remains as it was before these changes.

The cubename tool has been made aware of the 'container' image produced by WRL.
