### PR TITLE
cubeit-installer: respect prefix

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -608,7 +608,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
     export CNRECORD
 
     for c in `strip_properties ${HDINSTALL_CONTAINERS}`; do
-	cname=`${SBINDIR}/cubename $c`
+	cname=`${SBINDIR}/cubename $CNAME_PREFIX $c`
 
 	echo -n "Extracting rootfs $cname, with src $c....."
 
@@ -714,7 +714,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 
     #cleanup temp files
     for c in `strip_properties ${HDINSTALL_CONTAINERS}`; do
-        cname=`${SBINDIR}/cubename $c`
+        cname=`${SBINDIR}/cubename $CNAME_PREFIX $c`
         temp_dir=`cat ${CNRECORD}|awk -F ":" '{if ( $1=="'${cname}'" )print $2}'`
         rm $temp_dir -r
     done


### PR DESCRIPTION
Work done on commit 622ca316365d250c517705312df1aaa20b32bbe6
[cubeit-installer/cubename: allow file prefix] was tested with and
without prefixes but prior to the pull request being sent some changes
for shared filesystem were merge. When testing the rebase only the
non-prefix case was tested and it was not noticed that several new
calls to the cubename script were added.

Adding the passing of the prefix to these new call sites.

Signed-off-by: Mark Asselstine mark.asselstine@windriver.com
