### PR TITLE
cubeit: Fix passing the parameter of --config to cubeit-installer

### DIFF
--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -618,8 +618,8 @@ case $TARGET_TYPE in
 	fi
 
 	if [ -z "${TARGET_CONFIG_FILE}" ]; then
-	    if [ -n "${CONFIG_FILE}" ]; then
-		TARGET_CONFIG_FILE=${CONFIG_FILE}
+	    if [ -n "${CONFIG_FILES}" ]; then
+		TARGET_CONFIG_FILE="${CONFIG_FILES}"
 	    else
 		TARGET_CONFIG_FILE="config-live.sh"
 	    fi

--- a/sbin/scanduplicate
+++ b/sbin/scanduplicate
@@ -18,12 +18,13 @@ scandir()
 {
 # Search each entry in base_path, delete same file in target_path.
 for entry in $(ls $1 -A); do
-    if [ -e "$2/${entry}" ] || [ -L "$2/${entry}" ]; then
+    if [ -e "$2/${entry}" ]; then
         if [ -d "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
             [ -d "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
             # Only enter dir when both $1/entry & $2/entry are directory
             scandir "$1/$entry" "$2/$entry"
-        elif [ -f "$2/${entry}" ] && [ -f "$1/${entry}" ]; then
+        elif [ -f "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
+              [ -f "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
             # Delete when both $1/entry & $2/entry are regular file
             FILE=`echo "$2/${entry}"|sed "s:${TARGET_PATH}/::g"`
             echo "removed ${FILE}"


### PR DESCRIPTION
A typo in cubeit causes the following error:

/buildarea1/jzhang0/overc-installer/sbin/../installers/cubeit-installer: line 159: config-live.sh: No such file or directory

Signed-off-by: Lans Zhang jia.zhang@windriver.com
