### PR TITLE
scanduplicate: distinguish regular file and soft link file

### DIFF
--- a/sbin/scanduplicate
+++ b/sbin/scanduplicate
@@ -18,12 +18,13 @@ scandir()
 {
 # Search each entry in base_path, delete same file in target_path.
 for entry in $(ls $1 -A); do
-    if [ -e "$2/${entry}" ] || [ -L "$2/${entry}" ]; then
+    if [ -e "$2/${entry}" ]; then
         if [ -d "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
             [ -d "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
             # Only enter dir when both $1/entry & $2/entry are directory
             scandir "$1/$entry" "$2/$entry"
-        elif [ -f "$2/${entry}" ] && [ -f "$1/${entry}" ]; then
+        elif [ -f "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
+              [ -f "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
             # Delete when both $1/entry & $2/entry are regular file
             FILE=`echo "$2/${entry}"|sed "s:${TARGET_PATH}/::g"`
             echo "removed ${FILE}"


### PR DESCRIPTION
The trival fixes include:
- -e implies -L test.
- -f cannot distinguish between regular file and soft link file.

Signed-off-by: Lans Zhang jia.zhang@windriver.com
