### PR TITLE
Improve cold boot time: Remove hard sleep from rootdelay

### DIFF
--- a/files/grub-usb.cfg
+++ b/files/grub-usb.cfg
@@ -1,9 +1,9 @@
 set default=0
-set timeout=5
+set timeout=1
 set root=(hd0,1)
 
 menuentry "%DISTRIBUTION% Installer" {
 	set root=(hd0,1)
-	linux /images/%INSTALL_KERNEL% rootwait root=LABEL=%ROOTFS_LABEL% rootdelay=3
+	linux /images/%INSTALL_KERNEL% rootwait root=LABEL=%ROOTFS_LABEL%
 	initrd /images/%INSTALL_INITRAMFS%
 }

--- a/files/menu.lst.initramfs-installer
+++ b/files/menu.lst.initramfs-installer
@@ -2,5 +2,5 @@ default		0
 timeout		5
 
 title		%DISTRIBUTION% Installer
-kernel		/images/bzImage rootdelay=5 root=LABEL=%ROOTFS_LABEL%
+kernel		/images/bzImage rootwait root=LABEL=%ROOTFS_LABEL%
 initrd		/images/%INSTALL_INITRAMFS%

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -497,7 +497,7 @@ menuentry "$DISTRIBUTION" {
 	insmod fat
 	search --no-floppy --label OVERCBOOT --set=root 
 	echo	'Loading Linux ...'
-	linux	/bzImage root=LABEL=OVERCROOTFS ro rootdelay=3
+	linux	/bzImage root=LABEL=OVERCROOTFS ro rootwait
 	echo	'Loading initial ramdisk ...'
 	initrd	/initrd
 }
@@ -508,7 +508,7 @@ menuentry "$DISTRIBUTION recovery" {
         insmod fat
         search --no-floppy --label OVERCBOOT --set=root 
         echo    'Loading Linux ...'
-        linux   /bzImage_bakup root=LABEL=OVERCROOTFS rootflags=subvol=rootfs_bakup ro rootdelay=3
+        linux   /bzImage_bakup root=LABEL=OVERCROOTFS rootflags=subvol=rootfs_bakup ro rootwait
         echo    'Loading initial ramdisk ...'
         initrd  /initrd
 }

--- a/sbin/startup.nsh
+++ b/sbin/startup.nsh
@@ -1,6 +1,6 @@
 set fs fs0
 set root LABEL=%ROOTLABEL%
-set args "initrd=%INITRD% rootwait rootdelay=3"
+set args "initrd=%INITRD% rootwait"
 
 %fs%:
 cd %fs%:\


### PR DESCRIPTION
On modern  hardware the  rootdelay is not  needed.  The  rootwait will
wait for any kind of slow responding  USB device that takes a while to
come back from a bus reset.

Also the default grub timeout goes from 5 seconds to 1 second, which
means you can still interrupt boot sequence if absolutely needed, but
the general case of cold booting is faster.

Signed-off-by: Jason Wessel jason.wessel@windriver.com
