### PR TITLE
cubeit: add ROOTFS_LABEL sanity check

### DIFF
--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -206,6 +206,18 @@ for config in ${CONFIG_FILES}; do
     source `basename ${config_to_source}`
 done
 
+# config sanity check
+if [ "${#ROOTFS_LABEL}" -gt 16 ]; then
+	echo "The length of the ROOTFS_LABEL is greater than 16, will be stipped to: ${ROOTFS_LABEL:0:16}"
+	read -p "Do you wish to continue? [y/n] " -n 1
+	echo
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		ROOTFS_LABEL=${ROOTFS_LABEL:0:16}
+	else
+		exit 1
+	fi
+fi
+
 if ! [ -n "$DISTRIBUTION" ]; then
     DISTRIBUTION="OverC"
 fi


### PR DESCRIPTION
The max label length of ext2 filesystem is 16. So if user set a label
with length longer than 16, the system will fail to boot because
e2label will strip the length to 16. So add check and confirm for end
user to choose.

Signed-off-by: Feng Mu Feng.Mu@windriver.com
