### PR TITLE
config*.sh: rename default BOOTPART_LABEL and ROOTFS_LABEL

### DIFF
--- a/config/config-hd.sh.sample
+++ b/config/config-hd.sh.sample
@@ -27,12 +27,12 @@ HARDDRIVE_MODEL="ST9120822SB     "
 BOOTPART_START="0"
 BOOTPART_END="250M"
 BOOTPART_FSTYPE="fat32"
-BOOTPART_LABEL="boot"
+BOOTPART_LABEL="OVERCBOOT"
 
 ROOTFS_START="250M"
 ROOTFS_END="-1"	# Specify -1 to use the rest of drive
 ROOTFS_FSTYPE="ext2"
-ROOTFS_LABEL="rootfs"
+ROOTFS_LABEL="OVERCINSTROOTFS"
 
 HARDDRIVE_BANNER="Wind River Hard Drive Installer
 --------------------------------------------------------------------------------

--- a/config/config-usb.sh.sample
+++ b/config/config-usb.sh.sample
@@ -49,12 +49,12 @@ DISTRIBUTION="OverC"
 BOOTPART_START="63s"
 BOOTPART_END="250M"
 BOOTPART_FSTYPE="fat32"
-BOOTPART_LABEL="boot"
+BOOTPART_LABEL="OVERCBOOT"
 
 ROOTFS_START="250M"
 ROOTFS_END="-1"	# Specify -1 to use the rest of drive
 ROOTFS_FSTYPE="ext2"
-ROOTFS_LABEL="rootfs"
+ROOTFS_LABEL="OVERCINSTROOTFS"
 
 USBSTORAGE_BANNER="USB Creator for the Hard Drive Installer
 --------------------------------------------------------------------------------


### PR DESCRIPTION
As "boot" and "rootfs" label are too common to conflict with other
partitions on other disks, the installer might lead the kernel to a
wrong rootfs partition and thus fail to start the installer itself.
So we should make this default label more special.

Signed-off-by: Feng Mu Feng.Mu@windriver.com
