### PR TITLE
overc-installer: delay cleanup the snapshots when rollback itself 

### DIFF
--- a/files/overc_cleanup.service
+++ b/files/overc_cleanup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Clean up the unused container snapshots
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/overc-installer/overc-cctl clean
+ExecStop=/bin/systemctl disable overc_cleanup.service
+
+[Install]
+WantedBy=multi-user.target

--- a/sbin/overc-cctl
+++ b/sbin/overc-cctl
@@ -2,6 +2,23 @@
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License version 2 as
 #  published by the Free Software Foundation.
+CGROUP_NAME="cpuset"
+
+function get_cn_name_from_init_pid {
+    local init_pid=${1}
+
+    cn_name=$(cat /proc/${init_pid}/cgroup | grep ":${CGROUP_NAME}:" |\
+            cut -d ":" -f 3 | xargs basename)
+    echo "${cn_name}"
+}
+
+function is_current_cn {
+    local cn_name=${1}
+
+    current_cn_name=$(get_cn_name_from_init_pid 1)
+    [ "${current_cn_name}" == "${cn_name}" ] && return 1
+    return 0
+}
 
 if [ "$CUBE_DEBUG_SET_X_IF_SET" = 1 ] ; then
     set -x
@@ -878,13 +895,20 @@ function rollback_container {
 	fi
 	if [ "${result}" == "y" ]; then
 		switch_container ${contver} delhist
-		# Cleanup any stray snapshots after a rollback
-		for c in $(cd ${lxcbase}/${containers} && ls -1dr ${cn}/* 2>/devnull) ; do
-			get_container_attributes ${c}
-			if [ ${current} == 0 ] && [ ${inhist} == 0 ]; then
-				remove_subvol_recursive "${lxcbase}/${containers}/${c}"
-			fi
-		done
+		#we cannot cleanup himself at present, and
+		#delay the cleanup in the next boot up.
+		is_current_cn $cn
+		if [ $? -eq 1 ]; then
+			ln -sf /lib/systemd/system/overc_cleanup.service ${lxcbase}/${cn}/rootfs/etc/systemd/system/multi-user.target.wants/overc_cleanup.service
+		else
+			# Cleanup any stray snapshots after a rollback
+			for c in $(cd ${lxcbase}/${containers} && ls -1dr ${cn}/* 2>/devnull) ; do
+				get_container_attributes ${c}
+				if [ ${current} == 0 ] && [ ${inhist} == 0 ]; then
+					remove_subvol_recursive "${lxcbase}/${containers}/${c}"
+				fi
+			done
+		fi
 		exit 0
 	fi
 	echo "No snapshot selected, aborting"


### PR DESCRIPTION
When container do rollback itself, such as rollback dom0 in
dom0, it shouldn't do clean at present, instead it should
delay the cleanup to the next boot up, otherwise, dom0
will crash and cannot do any commands.

Signed-off-by: fli fupan.li@windriver.com
