### PR TITLE
installer: minor fixes

### DIFF
--- a/config/config-hd.sh.sample
+++ b/config/config-hd.sh.sample
@@ -50,20 +50,4 @@ CONFIRM_REBOOT=1
 
 CMD_GRUB_INSTALL="/bin/bash /sbin/grub-install"
 
-######################################################################
-# Define some debug output variables
-
-# Debug Levels - fixed values
-DEBUG_SILENT=0
-DEBUG_CRIT=1
-DEBUG_WARN=2
-DEBUG_INFO=4
-DEBUG_VERBOSE=7
-
-# Set your default debug level
-: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
-
-# Dynamic debug level
-DEBUG_LEVEL=${DEBUG_DEFAULT}
-
-: ${TRACE:=0}
+DEBUG_LEVEL=${DEBUG_VERBOSE}

--- a/config/config-usb.sh.sample
+++ b/config/config-usb.sh.sample
@@ -97,23 +97,7 @@ SERVICE_CONDITION_CONTAINER=" \
   watchdog \
 "
 
-######################################################################
-# Define some debug output variables
-
-# Debug Levels - fixed values
-DEBUG_SILENT=0
-DEBUG_CRIT=1
-DEBUG_WARN=2
-DEBUG_INFO=4
-DEBUG_VERBOSE=7
-
-# Set your default debug level
-: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
-
-# Dynamic debug level
 DEBUG_LEVEL=${DEBUG_DEFAULT}
-
-: ${TRACE:=0}
 
 CONFIG_FILE_ARM="config-usb-arm.sh"
 export X86_ARCH=true

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -785,7 +785,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	debugmsg ${DEBUG_INFO} "[INFO]: Using bridged networking."
     else
 	if [ ! -v NETWORK_DEVICE ]; then
-	    NETWORK_DEVICE="enp0s3"
+	    NETWORK_DEVICE="enp1s0"
 	fi
 	if [ ! -v NETWORK_DEVICE_CLASSES ]; then
 	    NETWORK_DEVICE_CLASSES="eth* wl* en*"

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -631,9 +631,9 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
     for c in `strip_properties ${HDINSTALL_CONTAINERS}`; do
 	cname=`${SBINDIR}/cubename $CNAME_PREFIX $c`
 	# Just save a record in tmp file
-	mergepatch=`get_prop_value_by_container $cname "mergepath"`
+	mergepath=`get_prop_value_by_container $cname "mergepath"`
 
-	echo "$cname::$mergepatch" >> ${CNRECORD}
+	echo "$cname::$mergepath" >> ${CNRECORD}
     done;
 
     for c in `strip_properties ${HDINSTALL_CONTAINERS}`; do

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -146,6 +146,32 @@ if [ -n "$ARTIFACTS_DIR" ]; then
 fi
 export ARTIFACTS_DIR
 
+## Load functions file
+if ! [ -e $FUNCTIONS_FILE ]
+then
+	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
+	exit 1
+fi
+source $FUNCTIONS_FILE
+
+######################################################################
+# Define some debug output variables
+
+# Debug Levels - fixed values
+DEBUG_SILENT=0
+DEBUG_CRIT=1
+DEBUG_WARN=2
+DEBUG_INFO=4
+DEBUG_VERBOSE=7
+
+# Set your default debug level
+: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
+
+# Dynamic debug level
+DEBUG_LEVEL=${DEBUG_DEFAULT}
+
+: ${TRACE:=0}
+
 # command line parameters can be:
 #   <target> (device, directory or file)
 target=$1
@@ -168,15 +194,6 @@ fi
 if [ "$TARGET_TYPE" = "block" ]; then
     USBSTORAGE_DEVICE=/sys/block/$(basename "$target")
 fi
-
-
-## Load functions file
-if ! [ -e $FUNCTIONS_FILE ]
-then
-	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
-	exit 1
-fi
-source $FUNCTIONS_FILE
 
 ## Load configuration file(s)
 if [ -z ${CONFIG_FILES} ]; then

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -622,7 +622,7 @@ install_grub()
 	
 	#install efi boot
 
-	if [ -n "${INSTALL_EFIBOOT}" ]; then
+	if [ -n "${INSTALL_EFIBOOT}" ] && [ -e "${INSTALL_EFIBOOT}" ]; then
 		debugmsg ${DEBUG_INFO} "Installing the EFI bootloader"
 		mkdir -p ${mountpoint}/EFI/BOOT/
 		cp $INSTALL_EFIBOOT ${mountpoint}/EFI/BOOT/

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -35,7 +35,7 @@ debugmsg()
 	local msg_level=$1
 	shift
 
-	if [ -z $msg_level ]
+	if [ -z "$msg_level" ]
 	then
 		echo "debugmsg: No debug level specified with message." >&2
 	fi

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -301,7 +301,7 @@ validate_harddrive()
 
 	if [ -z ${harddrive_device} ] || [ -z ${harddrive_model} ]
 	then
-		debugmsg ${DEBUG_CRIT} "ERROR: Input parameters not provided"
+		debugmsg ${DEBUG_CRIT} "ERROR: validate_harddrive input parameters not provided"
 		return 1
 	fi
 
@@ -332,7 +332,7 @@ remove_partitions()
 
 	if [ -z $device ]
 	then
-		debugmsg ${DEBUG_CRIT} "ERROR: Input parameters not provided"
+		debugmsg ${DEBUG_CRIT} "ERROR: remove_partitions input parameters not provided"
 	fi
 
 	debugmsg ${DEBUG_INFO} "Removing all partitions"
@@ -369,7 +369,7 @@ create_partition()
 
 	if [ -z $device ]
 	then
-		debugmsg ${DEBUG_CRIT} "ERROR: Input parameters not provided"
+		debugmsg ${DEBUG_CRIT} "ERROR: create_partition input parameters not provided"
 	fi
 
 	debugmsg ${DEBUG_INFO} "Creating partition ${device}${partnum}"
@@ -403,7 +403,7 @@ create_filesystem()
 
 	if [ -z $partition ]
 	then
-		debugmsg ${DEBUG_CRIT} "ERROR: Input parameters not provided"
+		debugmsg ${DEBUG_CRIT} "ERROR: create_filesystem input parameters not provided"
 		return 1
 	fi
 
@@ -503,7 +503,7 @@ umount_partitions()
 
 	if [ -z $device ]
 	then
-		debugmsg ${DEBUG_CRIT} "ERROR: Input parameters not provided"
+		debugmsg ${DEBUG_CRIT} "ERROR: umount_partitions input parameters not provided"
 	fi
 
 	sync


### PR DESCRIPTION
commit 5bc4e11c7818005592ae112db1980834c9003d29
Author: Feng Mu Feng.Mu@windriver.com
Date:   Tue Aug 23 16:22:02 2016 +0800

```
cubeit: add debug definitions

These debug definitions are currently only available in the provided
config samples, which might lead to syntax error if no config files are
specified when doing the command. So move the level definitions here
and keep only the level configuration in the sample configuration files.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit 78a35fc3b9f77b10a3c2a7469ca8d378c7352ab7
Author: Feng Mu Feng.Mu@windriver.com
Date:   Tue Aug 23 15:43:53 2016 +0800

```
installer: change default name to enp1s0

Currently the default name for the first ethernet device is enp1s0. So
we should make this as default if user doesn't specify one.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit e3f189fbe66d495aaea2c683fb93522988617b23
Author: Feng Mu Feng.Mu@windriver.com
Date:   Tue Aug 23 15:31:54 2016 +0800

```
efiboot: add file existance checking

Currently the efiboot file is not checked for existance, which might
lead to boot failure if continue to install while file not present.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit a0b249dc7f4a04a868253a323474faf3fd494384
Author: Feng Mu Feng.Mu@windriver.com
Date:   Tue Aug 23 15:27:45 2016 +0800

```
functions: make debug message more specific

The message:

  ERROR: Input parameters not provided

is too general to distinguish from others. Add function name so that
user can have more info on that.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit f997770a06d2f9aaa339faed53577185a50fdb0d
Author: Feng Mu Feng.Mu@windriver.com
Date:   Tue Aug 23 15:17:57 2016 +0800

```
cubeit-installer: fix mergepath typo

mergepatch -> mergepath

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```
