### PR TITLE
installer: fix issue 13 and 16 and some others

### DIFF
--- a/config/config-hd.sh.sample
+++ b/config/config-hd.sh.sample
@@ -50,20 +50,4 @@ CONFIRM_REBOOT=1
 
 CMD_GRUB_INSTALL="/bin/bash /sbin/grub-install"
 
-######################################################################
-# Define some debug output variables
-
-# Debug Levels - fixed values
-DEBUG_SILENT=0
-DEBUG_CRIT=1
-DEBUG_WARN=2
-DEBUG_INFO=4
-DEBUG_VERBOSE=7
-
-# Set your default debug level
-: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
-
-# Dynamic debug level
-DEBUG_LEVEL=${DEBUG_DEFAULT}
-
-: ${TRACE:=0}
+DEBUG_LEVEL=${DEBUG_VERBOSE}

--- a/config/config-usb.sh.sample
+++ b/config/config-usb.sh.sample
@@ -97,23 +97,9 @@ SERVICE_CONDITION_CONTAINER=" \
   watchdog \
 "
 
-######################################################################
-# Define some debug output variables
-
-# Debug Levels - fixed values
-DEBUG_SILENT=0
-DEBUG_CRIT=1
-DEBUG_WARN=2
-DEBUG_INFO=4
-DEBUG_VERBOSE=7
-
-# Set your default debug level
-: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
-
-# Dynamic debug level
-DEBUG_LEVEL=${DEBUG_DEFAULT}
-
-: ${TRACE:=0}
+# Override the default level here.
+# The level definitions can be found in the sbin/cubeit
+#DEBUG_LEVEL=${DEBUG_VERBOSE}
 
 CONFIG_FILE_ARM="config-usb-arm.sh"
 export X86_ARCH=true

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -132,27 +132,7 @@ if [ -z "${CONFIG_FILES}" ]; then
     CONFIG_FILES="config-installer.sh"
 fi
 
-colon_separated_config_dirs=`echo ${CONFIG_DIRS} | sed 's/ /:/g'`
-for config in ${CONFIG_FILES}; do
-    config_to_source="${config}"
-
-    # check to see if the config exists. If it doesn't search the config paths
-    if ! [ -e "${config}" ]; then
-	for d in ${CONFIG_DIRS}; do
-	    if [ -e "${d}/${config}" ]; then
-		config_to_source="${d}/${config}"
-	    fi
-	done
-
-	if [ -z "${config_to_source}" ]; then
-	    echo "ERROR: Could not find configuration file (${config_to_soure})."
-	    echo "Try using an absolute path or the file must be in one of ($(echo ${CONFIG_DIRS} | tr ' ' ','))."
-	    exit 1
-	fi
-    fi
-    export PATH="$PATH:${colon_separated_config_dirs}:$( dirname $config_to_source )"
-    source `basename ${config_to_source}`
-done
+source_conffiles
 
 OLDIFS=$IFS
 IFS='

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -146,6 +146,32 @@ if [ -n "$ARTIFACTS_DIR" ]; then
 fi
 export ARTIFACTS_DIR
 
+## Load functions file
+if ! [ -e $FUNCTIONS_FILE ]
+then
+	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
+	exit 1
+fi
+source $FUNCTIONS_FILE
+
+######################################################################
+# Define some debug output variables
+
+# Debug Levels - fixed values
+DEBUG_SILENT=0
+DEBUG_CRIT=1
+DEBUG_WARN=2
+DEBUG_INFO=4
+DEBUG_VERBOSE=7
+
+# Set your default debug level
+: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
+
+# Dynamic debug level
+DEBUG_LEVEL=${DEBUG_DEFAULT}
+
+: ${TRACE:=0}
+
 # command line parameters can be:
 #   <target> (device, directory or file)
 target=$1
@@ -168,15 +194,6 @@ fi
 if [ "$TARGET_TYPE" = "block" ]; then
     USBSTORAGE_DEVICE=/sys/block/$(basename "$target")
 fi
-
-
-## Load functions file
-if ! [ -e $FUNCTIONS_FILE ]
-then
-	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
-	exit 1
-fi
-source $FUNCTIONS_FILE
 
 ## Load configuration file(s)
 if [ -z ${CONFIG_FILES} ]; then

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -257,6 +257,7 @@ done
 
 trap_cmd='trap_handler $?'
 trap "${trap_cmd}" EXIT
+trap "clean_up \"Action cancelled by user.\"" SIGINT
 
 case $TARGET_TYPE in
     block)

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -184,39 +184,7 @@ if [ -z ${CONFIG_FILES} ]; then
     exit 1
 fi
 
-colon_separated_config_dirs=`echo ${CONFIG_DIRS} | sed 's/ /:/g'`
-for config in ${CONFIG_FILES}; do
-    config_to_source="${config}"
-
-    # check to see if the config exists. If it doesn't search the config paths
-    if ! [ -e "${config}" ]; then
-	for d in ${CONFIG_DIRS}; do
-	    if [ -e "${d}/${config}" ]; then
-		config_to_source="${d}/${config}"
-	    fi
-	done
-
-	if [ -z "${config_to_source}" ]; then
-	    echo "ERROR: Could not find configuration file (${config_to_soure})."
-	    echo "Try using an absolute path or the file must be in one of ($(echo ${CONFIG_DIRS} | tr ' ' ','))."
-	    exit 1
-	fi
-    fi
-    export PATH="$PATH:${colon_separated_config_dirs}:$(dirname ${config_to_source})"
-    source `basename ${config_to_source}`
-done
-
-# config sanity check
-if [ "${#ROOTFS_LABEL}" -gt 16 ]; then
-	echo "The length of the ROOTFS_LABEL is greater than 16, will be stripped to: ${ROOTFS_LABEL:0:16}"
-	read -p "Do you wish to continue? [y/n] " -n 1
-	echo
-	if [[ $REPLY =~ ^[Yy]$ ]]; then
-		ROOTFS_LABEL=${ROOTFS_LABEL:0:16}
-	else
-		exit 1
-	fi
-fi
+source_conffiles
 
 if ! [ -n "$DISTRIBUTION" ]; then
     DISTRIBUTION="OverC"

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -976,6 +976,9 @@ installer_main()
 	create_partition "${dev}" 2 ${ROOTFS_FSTYPE} ${ROOTFS_START} ${ROOTFS_END}
 	assert $?
 
+	# make first partition bootable
+	/sbin/parted /dev/${device} set 1 boot on > /dev/null 2>&1
+
 	local p1
 	local p2
 	# XXX: TODO. the partition name should be returned by create_partition

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -35,7 +35,7 @@ debugmsg()
 	local msg_level=$1
 	shift
 
-	if [ -z $msg_level ]
+	if [ -z "$msg_level" ]
 	then
 		echo "debugmsg: No debug level specified with message." >&2
 	fi

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -935,6 +935,42 @@ extract_tarball()
 	return 0
 }
 
+source_conffiles()
+{
+	colon_separated_config_dirs=`echo ${CONFIG_DIRS} | sed 's/ /:/g'`
+	for config in ${CONFIG_FILES}; do
+		config_to_source="${config}"
+
+		# check to see if the config exists. If it doesn't search the config paths
+		if ! [ -e "${config}" ]; then
+			for d in ${CONFIG_DIRS}; do
+				if [ -e "${d}/${config}" ]; then
+					config_to_source="${d}/${config}"
+				fi
+			done
+
+			if [ -z "${config_to_source}" ]; then
+				echo "ERROR: Could not find configuration file (${config_to_soure})."
+				echo "Try using an absolute path or the file must be in one of ($(echo ${CONFIG_DIRS} | tr ' ' ','))."
+				exit 1
+			fi
+		fi
+		export PATH="$PATH:${colon_separated_config_dirs}:$(dirname ${config_to_source})"
+		source `basename ${config_to_source}`
+	done
+	# config sanity check
+	if [ "${#ROOTFS_LABEL}" -gt 16 ]; then
+		echo "The length of the ROOTFS_LABEL is greater than 16, will be stripped to: ${ROOTFS_LABEL:0:16}"
+		read -p "Do you wish to continue? [y/n] " -n 1
+		echo
+		if [[ $REPLY =~ ^[Yy]$ ]]; then
+			ROOTFS_LABEL=${ROOTFS_LABEL:0:16}
+		else
+			exit 1
+		fi
+	fi
+}
+
 clean_up()
 {
 	# Cleanup

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -935,6 +935,21 @@ extract_tarball()
 	return 0
 }
 
+clean_up()
+{
+	# Cleanup
+	debugmsg ${DEBUG_INFO} "Unmounting all partitions"
+	sync
+	[ -n "${mnt1}" ] && umount ${mnt1}
+	[ -n "${mnt2}" ] && umount ${mnt2}
+
+	# parameters passed by the SIGINT handle command
+	if [ -n "$1" ]; then
+		debugmsg ${DEBUG_INFO} $1
+		exit 0
+	fi
+}
+
 installer_main()
 {
 	local device="$1"
@@ -1028,13 +1043,9 @@ installer_main()
 		custom_install_rules "${mnt1}" "${mnt2}"
 		assert $?
 	fi
-	
-	# Cleanup
-	debugmsg ${DEBUG_INFO} "Unmounting all partitions"
-	sync
-	umount ${mnt1}
-	umount ${mnt2}
-	
+
+	clean_up
+
 	# Finish Installation
 	display_finalmsg
 	

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -982,6 +982,8 @@ installer_main()
 	local p1
 	local p2
 	# XXX: TODO. the partition name should be returned by create_partition
+	while ([ -z ${p1} ] || [ -z ${p2} ])
+	do
 	if [ -e /dev/${dev}1 ]; then
 	    p1="${dev}1"
 	    p2="${dev}2"
@@ -990,7 +992,8 @@ installer_main()
 	    p1="${dev}p1"
 	    p2="${dev}p2"
 	fi
-	
+	done
+
 	## Create new filesystems
 	debugmsg ${DEBUG_INFO} "Creating new filesystems "
 	create_filesystem "${p1}" "${BOOTPART_FSTYPE}" "${BOOTPART_LABEL}"


### PR DESCRIPTION
commit d77f13017a7580ea0981af61146fdc0ae3b50749
Author: Feng Mu Feng.Mu@windriver.com
Date:   Tue Aug 23 16:22:02 2016 +0800

```
cubeit: add debug definitions

These debug definitions are currently only available in the provided
config samples, which might lead to syntax error if no config files are
specified when doing the command. So move the level definitions here.
Configuration files can still override the debug level because they are
sourced after this definition.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit 70e16c1c8fc89164cecbf756beedb755f7d623a9
Author: Feng Mu Feng.Mu@windriver.com
Date:   Wed Aug 24 17:39:10 2016 +0800

```
config_files: use a unified function to source

Currently cubeit and cubeit-installer are using the same code when
sourcing the config files. Make it a function.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit 68447d1afcec15cb71fd9cea56cdfba0706453cd
Author: Feng Mu Feng.Mu@windriver.com
Date:   Wed Aug 24 17:33:54 2016 +0800

```
cleanup: add functions and hook SIGINT

The tmp mounts are not cleaned up if SIGINT is triggered. We should try
to clean it.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit e05e0e66f32b2f2d07b99624888fae5ae2486d7c
Author: Feng Mu Feng.Mu@windriver.com
Date:   Wed Aug 24 17:29:02 2016 +0800

```
functions: make sure partitions are there.

Issue: #13

There are cases that the newly created partition node is not available.
We should make sure that the correct values are set.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit 62ec391fe46221e5e4e9d7ece78c8a5014069d32
Author: Feng Mu Feng.Mu@windriver.com
Date:   Wed Aug 24 17:24:47 2016 +0800

```
installer: make first partition bootable

Issue: #16

The boot flag is not turned on by default, which prevents certain
boards from boot. We should turn it on by default.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```
