### PR TITLE
installer: fix issue 13 and 16 and some others

### DIFF
--- a/config/config-hd.sh.sample
+++ b/config/config-hd.sh.sample
@@ -50,20 +50,4 @@ CONFIRM_REBOOT=1
 
 CMD_GRUB_INSTALL="/bin/bash /sbin/grub-install"
 
-######################################################################
-# Define some debug output variables
-
-# Debug Levels - fixed values
-DEBUG_SILENT=0
-DEBUG_CRIT=1
-DEBUG_WARN=2
-DEBUG_INFO=4
-DEBUG_VERBOSE=7
-
-# Set your default debug level
-: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
-
-# Dynamic debug level
-DEBUG_LEVEL=${DEBUG_DEFAULT}
-
-: ${TRACE:=0}
+DEBUG_LEVEL=${DEBUG_VERBOSE}

--- a/config/config-usb.sh.sample
+++ b/config/config-usb.sh.sample
@@ -97,23 +97,9 @@ SERVICE_CONDITION_CONTAINER=" \
   watchdog \
 "
 
-######################################################################
-# Define some debug output variables
-
-# Debug Levels - fixed values
-DEBUG_SILENT=0
-DEBUG_CRIT=1
-DEBUG_WARN=2
-DEBUG_INFO=4
-DEBUG_VERBOSE=7
-
-# Set your default debug level
-: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
-
-# Dynamic debug level
-DEBUG_LEVEL=${DEBUG_DEFAULT}
-
-: ${TRACE:=0}
+# Override the default level here.
+# The level definitions can be found in the sbin/cubeit
+#DEBUG_LEVEL=${DEBUG_VERBOSE}
 
 CONFIG_FILE_ARM="config-usb-arm.sh"
 export X86_ARCH=true

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -146,6 +146,32 @@ if [ -n "$ARTIFACTS_DIR" ]; then
 fi
 export ARTIFACTS_DIR
 
+## Load functions file
+if ! [ -e $FUNCTIONS_FILE ]
+then
+	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
+	exit 1
+fi
+source $FUNCTIONS_FILE
+
+######################################################################
+# Define some debug output variables
+
+# Debug Levels - fixed values
+DEBUG_SILENT=0
+DEBUG_CRIT=1
+DEBUG_WARN=2
+DEBUG_INFO=4
+DEBUG_VERBOSE=7
+
+# Set your default debug level
+: ${DEBUG_DEFAULT:=${DEBUG_INFO}}
+
+# Dynamic debug level
+DEBUG_LEVEL=${DEBUG_DEFAULT}
+
+: ${TRACE:=0}
+
 # command line parameters can be:
 #   <target> (device, directory or file)
 target=$1
@@ -168,15 +194,6 @@ fi
 if [ "$TARGET_TYPE" = "block" ]; then
     USBSTORAGE_DEVICE=/sys/block/$(basename "$target")
 fi
-
-
-## Load functions file
-if ! [ -e $FUNCTIONS_FILE ]
-then
-	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
-	exit 1
-fi
-source $FUNCTIONS_FILE
 
 ## Load configuration file(s)
 if [ -z ${CONFIG_FILES} ]; then

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -254,9 +254,7 @@ for d in ${CONFIG_DIRS} $BASEDIR; do
 done
 
 ## Set up trap handler
-
-trap_cmd='trap_handler $?'
-trap "${trap_cmd}" EXIT
+trap_with_name "trap_handler" EXIT SIGINT
 
 case $TARGET_TYPE in
     block)

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -976,6 +976,9 @@ installer_main()
 	create_partition "${dev}" 2 ${ROOTFS_FSTYPE} ${ROOTFS_START} ${ROOTFS_END}
 	assert $?
 
+	# make first partition bootable
+	/sbin/parted /dev/${device} set 1 boot on > /dev/null 2>&1
+
 	local p1
 	local p2
 	# XXX: TODO. the partition name should be returned by create_partition

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -35,7 +35,7 @@ debugmsg()
 	local msg_level=$1
 	shift
 
-	if [ -z $msg_level ]
+	if [ -z "$msg_level" ]
 	then
 		echo "debugmsg: No debug level specified with message." >&2
 	fi


### PR DESCRIPTION
commit 3b6fba003e0f8081c5521d3ee33e26a12bd8f237
Author: Feng Mu Feng.Mu@windriver.com
Date:   Tue Aug 23 16:22:02 2016 +0800

```
cubeit: add debug definitions

These debug definitions are currently only available in the provided
config samples, which might lead to syntax error if no config files are
specified when doing the command. So move the level definitions here.
Configuration files can still override the debug level because they are
sourced after this definition.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit d6ded61c38e445936ae28baa9b80288f25692e43
Author: Feng Mu Feng.Mu@windriver.com
Date:   Wed Aug 24 17:33:54 2016 +0800

```
cleanup: add functions and hook SIGINT

The tmp mounts are not cleaned up if SIGINT is triggered. We should try
to clean it.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit 783b6bf9fb25d43541499e5b74c92fa9df748711
Author: Feng Mu Feng.Mu@windriver.com
Date:   Wed Aug 24 17:29:02 2016 +0800

```
functions: make sure partitions are there.

Issue: #13

There are cases that the newly created partition node is not available.
We should make sure that the correct values are set.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```

commit 66ea763fc4c03d6a5533a6f87d84beb467bf8d7d
Author: Feng Mu Feng.Mu@windriver.com
Date:   Wed Aug 24 17:24:47 2016 +0800

```
installer: make first partition bootable

Issue: #16

The boot flag is not turned on by default, which prevents certain
boards from boot. We should turn it on by default.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>
```
