### PR TITLE
overc-installer:create mask dir for overlay dir

### DIFF
--- a/sbin/overc-cctl
+++ b/sbin/overc-cctl
@@ -646,9 +646,11 @@ function add_container {
 		sizeinfo_ori=`du -BM ${container_tmppath}/rootfs${dir} -d 0|awk '{print $1;}'`
 
 		# perform merge container ${TMPMNT}${dir} ${container_tmppath}${merged_dir}
-		fstab_entry="overlay /var/lib/lxc/${cn}/rootfs${dir} overlay lowerdir="
+		fstab_entry="overlay /var/lib/lxc/${cn}/rootfs${dir} overlay lowerdir=/var/lib/lxc/${cn}${dir}_mask"
 
-		fstab_mark=0
+		# create a mask dir
+		mkdir ${pathtocontainer}${dir}_mask
+
 		for target_entry in ${target}; do
 			if [ ${target_entry} == "essential" ]; then
 				lowerdir="${TMPMNT}${dir}"
@@ -670,16 +672,10 @@ function add_container {
 			fi
 			echo "Merge ${dir} with ${target_entry}">>${merge_summary}
 
-			if [ $fstab_mark == 0 ]; then
-				fstab_mark=1
-			else
-				fstab_dir=":${fstab_dir}"
-			fi
-
 			# perform merge container ${lowerdir} ${container_tmppath}/rootfs${dir}
-			${SBINDIR}/scanduplicate ${lowerdir} ${container_tmppath}/rootfs${dir} >> ${merge_summary}
+			${SBINDIR}/scanduplicate ${lowerdir} ${container_tmppath}/rootfs${dir} ${pathtocontainer}${dir}_mask>> ${merge_summary}
 
-			fstab_entry="${fstab_entry}${fstab_dir}"
+			fstab_entry="${fstab_entry}:${fstab_dir}"
 		done;
 		# After merge, rename the dir with dir_temp in rootfs
 		if [ -d ${container_tmppath}/rootfs${dir} ]; then

--- a/sbin/scanduplicate
+++ b/sbin/scanduplicate
@@ -4,11 +4,11 @@ usage()
 {
 cat << EOF
 
-  scanduplicate <base_path> <target_path>
+  scanduplicate <base_path> <target_path> <mask_path>
 
   example:
 
-      $  scanduplicate essential/usr dom0/usr
+      $  scanduplicate essential/usr dom0/usr dom0/mask
 EOF
 }
 
@@ -18,11 +18,11 @@ scandir()
 {
 # Search each entry in base_path, delete same file in target_path.
 for entry in $(ls $1 -A); do
-    if [ -e "$2/${entry}" ]; then
+    if [ -e "$2/${entry}" ] || [ -L "$2/${entry}" ]; then
         if [ -d "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
             [ -d "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
             # Only enter dir when both $1/entry & $2/entry are directory
-            scandir "$1/$entry" "$2/$entry"
+            scandir "$1/$entry" "$2/$entry" "$3/$entry"
         elif [ -f "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
               [ -f "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
             # Delete when both $1/entry & $2/entry are regular file
@@ -36,6 +36,13 @@ for entry in $(ls $1 -A); do
             rm "$2/${entry}"
         fi
         # Ignore other conditions
+    elif [ ! -e "$3/${entry}" ]; then
+        # Create a mask file in mask_path
+	pathname=`dirname $3/${entry}`
+	if [ ! -d ${pathname} ]; then
+		mkdir -p ${pathname}
+	fi
+	mknod $3/${entry} c 0 0 --mode=000
     fi
 done;
 # Remove empty diretory in target_path
@@ -46,9 +53,14 @@ if [ $(ls -Al "$2"|wc -l) -eq 1 ]; then
 fi
 }
 
-if [ -z "$2" ]; then
+if [ -z "$3" ]; then
     usage
     exit
 fi
 
-scandir $1 $2
+if [ ! -d "$3" ]; then
+    usage
+    exit
+fi
+
+scandir $1 $2 $3


### PR DESCRIPTION
Overlayfs use character device file with major & minor number 0 as
special file to mask file in lowerdir.
Overc create a mask dir with such file to mask the file in source
container while not installed to container with overlay directory.

Signed-off-by: Jiang Lu lu.jiang@windriver.com
