### PR TITLE
cubeit-installer: Allow user to append kernel cmdline params

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,6 @@
+                         The OverC Installer
+                         -------------------
+
+A collection of scripts which are used to assemble the output of a
+meta-overc build (kernel, rootfs, containers) into an installer image
+(capable of performing an install) or live image.

--- a/README.variables
+++ b/README.variables
@@ -1,0 +1,32 @@
+The following is a description of some of the more commonly used
+variables employed during installer or live image creation.
+
+INSTALL_GRUBCFG:      The grub configuration file used when creating an
+                      installer image (unused when creating a live image).
+
+
+INSTALL_ROOTFS:       The 'bare metal' rootfs image. Passed to the installer
+                      when performing an install or creating a live image.
+
+
+HDINSTALL_ROOTFS:     The rootfs image which will be used as the rootfs of the
+                      installer (unused when creating a live image).
+
+
+HDINSTALL_CONTAINERS: In the case of installer generation this is the
+                      list of containers to cp to the install media,
+                      This list will be copied to the installer config
+                      and thus used when the installer performs an
+                      install. In the case of generatiing a live image
+                      this list will be the containers installed in
+                      the live image. Container names can include
+                      attribute suffixes.
+
+
+NETWORK_DEVICE:       The network device to passthrough to the network
+                      prime.  The network prime is defined by the
+                      'net=1' attribute being set for a container.
+
+
+GRUB_KERNEL_PARAMS:   Kernel parameters appended to the boot line used by the
+                      installed or live images. (cubeit-installer, x86 only).

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -497,7 +497,7 @@ menuentry "$DISTRIBUTION" {
 	insmod fat
 	search --no-floppy --label OVERCBOOT --set=root 
 	echo	'Loading Linux ...'
-	linux	/bzImage root=LABEL=OVERCROOTFS ro rootwait
+	linux	/bzImage root=LABEL=OVERCROOTFS ro rootwait $GRUB_KERNEL_PARAMS
 	echo	'Loading initial ramdisk ...'
 	initrd	/initrd
 }
@@ -508,7 +508,7 @@ menuentry "$DISTRIBUTION recovery" {
         insmod fat
         search --no-floppy --label OVERCBOOT --set=root 
         echo    'Loading Linux ...'
-        linux   /bzImage_bakup root=LABEL=OVERCROOTFS rootflags=subvol=rootfs_bakup ro rootwait
+        linux   /bzImage_bakup root=LABEL=OVERCROOTFS rootflags=subvol=rootfs_bakup ro rootwait $GRUB_RECOVERY_KERNEL_PARAMS
         echo    'Loading initial ramdisk ...'
         initrd  /initrd
 }


### PR DESCRIPTION
The installer uses a fixed grub configuration file at the moment, this
change allows some customization by the user by allowing them to
append to the kernel cmdline params. With this change they can, for
example, to sredirect the console output, or disable lapic.

Since I had to dig through the code to remind myself about how some of
the variables we set in the installer configuration I decided to start
documenting some of the more common variables to help myself and
others recall what these variables do. In order not to have thise
README show up in the github landing page a basic overview README was
added as well.

Signed-off-by: Mark Asselstine mark.asselstine@windriver.com
