### PR TITLE
installer: add interactive configuration process

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -16,6 +16,7 @@ fi
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #  See the GNU General Public License for more details.
 
+CURRENTDIR=$(pwd)
 BASEDIR=$(readlink -f $(dirname $BASH_SOURCE))
 IMAGESDIR="${BASEDIR}/../images"
 CONTAINERSDIR="${BASEDIR}/../images/containers"
@@ -72,6 +73,7 @@ cat << EOF
   cubeit-installer <base image> <device>
 
     -b: use btrfs
+    -I(--interactive): use the interactive configuration interface
     --finaldev: boot from this block dev. Default is vda
     --ttyconsoledev: set dev used for tty console
     --ttyconsolecn: set container name for providing agetty
@@ -106,6 +108,13 @@ while [ $# -gt 0 ]; do
             ;;
     -b) btrfs=1
             ;;
+	--interactive|-I)
+		# Interactive config mode
+		INTERACTIVE_MODE=1
+		for app in blockdev dialog; do
+			verify_utility $app || { echo >&2 "ERROR: $app is not available"; exit 1; }
+		done
+		;;
     --finaldev) final_dev="$2"
             shift
             ;;
@@ -168,7 +177,42 @@ if [ -e "${LOCAL_POST_FUNCTION_DEFS}" ] ; then
     source ${LOCAL_POST_FUNCTION_DEFS}
 fi
 
+## typical qemu disk is vdb
+rootfs=$1
+raw_dev=$2
+
+if [ -e "$rootfs" ]; then
+    rootfs=`readlink -f $rootfs`
+else
+    if [ ! -f "${IMAGESDIR}/$rootfs" ]; then
+	debugmsg ${DEBUG_CRIT} "[ERROR]: install rootfs ($rootfs) not found"
+	exit 1
+    fi
+    rootfs="${IMAGESDIR}/$rootfs"
+fi
+
+# remove /dev/ if specified
+raw_dev="`echo ${raw_dev} | sed 's|/dev/||'`"
+
 IFS=$OLDIFS
+
+# Check if interactive mode will be used
+INSTALL_TYPE="full"
+if [ -n "$INTERACTIVE_MODE" ] && [ "$INTERACTIVE_MODE" -eq 1 ]; then
+	debugmsg ${DEBUG_INFO} "Entering interactive mode..."
+	SAVE_CONFIG_FOLDER="saved_config"
+	recursive_mkdir ${SAVE_CONFIG_FOLDER}
+	interactive_config ${raw_dev} ${SAVE_CONFIG_FOLDER}
+	if [ $? -ne 0 ]; then
+		debugmsg ${DEBUG_CRIT} -e "\n\n\nFailed to generate one using interactive mode, run again or specify a config via --config option."
+		exit 1
+	else
+		debugmsg ${DEBUG_INFO} -e "\n\n\nUser config saved. Installation will continue."
+		debugmsg ${DEBUG_INFO} "You can specify --config ${SAVE_CONFIG_FOLDER}/config.sh option in your later installations to use the exact same configurations."
+		CONFIG_FILES="`pwd`/${SAVE_CONFIG_FOLDER}/config.sh"
+		source $CONFIG_FILES
+	fi
+fi
 
 if [ ! -d "${IMAGESDIR}" ]; then
     if [ -n "${ARTIFACTS_DIR}" ]; then
@@ -273,23 +317,6 @@ if [ -z "${privilegedcn}" ]; then
         privilegedcn="cube-desktop"
     fi
 fi
-
-## typical qemu disk is vdb
-rootfs=$1
-raw_dev=$2
-
-if [ -e "$rootfs" ]; then
-    rootfs=`readlink -f $rootfs`
-else
-    if [ ! -f "${IMAGESDIR}/$rootfs" ]; then
-	debugmsg ${DEBUG_CRIT} "[ERROR]: install rootfs ($rootfs) not found"
-	exit 1
-    fi
-    rootfs="${IMAGESDIR}/$rootfs"
-fi
-
-# remove /dev/ if specified
-raw_dev="`echo ${raw_dev} | sed 's|/dev/||'`"
 
 # create partitions
 # 
@@ -878,6 +905,9 @@ smart update"
 
 fi
 
+if [ -d "$CURRENTDIR/$PUPPETDIR" ]; then
+	PUPPETDIR=$CURRENTDIR/$PUPPETDIR
+fi
 if [ -d ${PUPPETDIR} ]; then
 	debugmsg ${DEBUG_INFO} "[INFO]: Running puppet"
 	cd ${TMPMNT}

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -17,6 +17,14 @@ fi
 
 : ${FUNCTIONS_FILE="$BASEDIR/functions.sh"}
 
+## Load functions file
+if ! [ -e $FUNCTIONS_FILE ]
+then
+	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
+	exit 1
+fi
+source $FUNCTIONS_FILE
+
 usage()
 {
 cat << EOF
@@ -33,6 +41,7 @@ cat << EOF
   options:
 
      --config <script>: use the specified configuration script found in ~/.overc/
+     -I(--interactive): use the interactive configuration interface
      --target-config <script>: use the specified configuration script found in ~/.overc/
                                when running the target installer
      --force: force overwrite any output files or images
@@ -101,6 +110,13 @@ while [ $# -gt 0 ]; do
 	    TARGET_DISK_SIZE="$2"
 	    shift
 	    ;;
+	--interactive|-I)
+		# Interactive config mode
+		INTERACTIVE_MODE=1
+		for app in blockdev dialog; do
+			verify_utility $app || { echo >&2 "ERROR: $app is not available"; exit 1; }
+		done
+		;;
     --installer)
 	    # create an installer, not a final image (this is the default)
             INSTALLER_IMAGE=t
@@ -146,14 +162,6 @@ if [ -n "$ARTIFACTS_DIR" ]; then
 fi
 export ARTIFACTS_DIR
 
-## Load functions file
-if ! [ -e $FUNCTIONS_FILE ]
-then
-	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
-	exit 1
-fi
-source $FUNCTIONS_FILE
-
 ######################################################################
 # Define some debug output variables
 
@@ -196,11 +204,6 @@ if [ "$TARGET_TYPE" = "block" ]; then
 fi
 
 ## Load configuration file(s)
-if [ -z ${CONFIG_FILES} ]; then
-    echo "ERROR: no configuration was provided via --config"
-    exit 1
-fi
-
 colon_separated_config_dirs=`echo ${CONFIG_DIRS} | sed 's/ /:/g'`
 for config in ${CONFIG_FILES}; do
     config_to_source="${config}"
@@ -232,6 +235,24 @@ if [ "${#ROOTFS_LABEL}" -gt 16 ]; then
 		ROOTFS_LABEL=${ROOTFS_LABEL:0:16}
 	else
 		exit 1
+	fi
+fi
+
+# Check if interactive mode will be used
+if [ -z ${CONFIG_FILES} ] || ([ -n "$INTERACTIVE_MODE" ] && [ "$INTERACTIVE_MODE" -eq 1 ]); then
+	debugmsg ${DEBUG_INFO} "Entering interactive mode..."
+	SAVE_CONFIG_FOLDER="saved_config"
+	recursive_mkdir ${SAVE_CONFIG_FOLDER}
+	interactive_config ${target} ${SAVE_CONFIG_FOLDER}
+	if [ $? -ne 0 ]; then
+		debugmsg ${DEBUG_CRIT} -e "\n\n\nFailed to generate one using interactive mode, run again or specify a config via --config option."
+		exit 1
+	else
+		debugmsg ${DEBUG_INFO} -e "\n\n\nUser config saved. Installation will continue."
+		debugmsg ${DEBUG_INFO} "You can specify --config ${SAVE_CONFIG_FOLDER}/config.sh option in your later installations to use the exact same configurations."
+		CONFIG_FILES="`pwd`/${SAVE_CONFIG_FOLDER}/config.sh"
+		TARGET_CONFIG_FILE=$CONFIG_FILES
+		source $CONFIG_FILES
 	fi
 fi
 
@@ -500,6 +521,7 @@ IFS=$OLDIFS
 	    # create a configuration that can be read by the cubeit-installer
 	    if [ -v TARGET_CONFIG_FILE -a -n "$TARGET_CONFIG_FILE" ]; then
 		cat $TARGET_CONFIG_FILE |
+			sed "s|ARTIFACTS_DIR=.*|ARTIFACTS_DIR=${INSTALLER_TARGET_IMAGES_DIR}|" | \
 			sed "s|\${ARTIFACTS_DIR}|${INSTALLER_TARGET_IMAGES_DIR}/containers|g" > \
 			${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
 	    else
@@ -527,9 +549,12 @@ IFS=$OLDIFS
 	# puppet modules etc.
 	if [ -v INSTALL_PUPPET_DIR ]; then
 	    if [ -d ${INSTALLER_FILES_DIR}/${INSTALL_PUPPET_DIR} ]; then
-		debugmsg ${DEBUG_INFO} "Copying Puppet files to install media"
-		recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/puppet
-		cp -r ${INSTALLER_FILES_DIR}/${INSTALL_PUPPET_DIR}/* ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/puppet/
+			INSTALL_PUPPET_DIR=${INSTALLER_FILES_DIR}/${INSTALL_PUPPET_DIR}
+		fi
+		if [ -d ${INSTALL_PUPPET_DIR} ]; then
+			debugmsg ${DEBUG_INFO} "Copying Puppet files to install media"
+			recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/puppet
+			cp -r ${INSTALL_PUPPET_DIR}/* ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/puppet/
 	    else
 		debugmsg ${DEBUG_INFO} "INSTALL_PUPPET_DIR set but directory doesn't exist."
 	    fi


### PR DESCRIPTION
Currently user must define a configuration file to lead the
installation process. In order to reduce the learning complexity of the
configuration items, we introduce this interactive process to guide the
user to genarate a configuration file and use that during the following
installation process.

This interactive process is triggered if no configuration file is
provided through the commandline or if interactive parameter
--interactive or -I is specifically provided through commandline.

The genarated configuration file can be reused later by passing through
the --config parameter.

Signed-off-by: Feng Mu Feng.Mu@windriver.com
