### PR TITLE
[v3]installer: add interactive configuration process

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -16,12 +16,14 @@ fi
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #  See the GNU General Public License for more details.
 
+CURRENTDIR=$(pwd)
 BASEDIR=$(readlink -f $(dirname $BASH_SOURCE))
 IMAGESDIR="${BASEDIR}/../images"
 CONTAINERSDIR="${BASEDIR}/../images/containers"
 PACKAGESDIR="${BASEDIR}/../packages"
 PUPPETDIR="${BASEDIR}/../files/puppet"
 SBINDIR="${BASEDIR}/../sbin"
+LIBDIR="${BASEDIR}/../lib"
 export SBINDIR
 if [ -z "${CONFIG_DIRS}" ] ; then
     CONFIG_DIRS="${BASEDIR}/../config $HOME/.overc/"
@@ -72,6 +74,7 @@ cat << EOF
   cubeit-installer <base image> <device>
 
     -b: use btrfs
+    -i or --interactive: use the interactive configuration interface
     --finaldev: boot from this block dev. Default is vda
     --ttyconsoledev: set dev used for tty console
     --ttyconsolecn: set container name for providing agetty
@@ -106,6 +109,13 @@ while [ $# -gt 0 ]; do
             ;;
     -b) btrfs=1
             ;;
+	--interactive|-i)
+		# Interactive config mode
+		INTERACTIVE_MODE=1
+		for app in blockdev dialog; do
+			verify_utility $app || { echo >&2 "ERROR: $app is not available"; exit 1; }
+		done
+		;;
     --finaldev) final_dev="$2"
             shift
             ;;
@@ -169,6 +179,53 @@ if [ -e "${LOCAL_POST_FUNCTION_DEFS}" ] ; then
 fi
 
 IFS=$OLDIFS
+
+## typical qemu disk is vdb
+rootfs=$1
+raw_dev=$2
+
+if [ -e "$rootfs" ]; then
+    rootfs=`readlink -f $rootfs`
+else
+    if [ ! -f "${IMAGESDIR}/$rootfs" ]; then
+	debugmsg ${DEBUG_CRIT} "[ERROR]: install rootfs ($rootfs) not found"
+	exit 1
+    fi
+    rootfs="${IMAGESDIR}/$rootfs"
+fi
+
+# remove /dev/ if specified
+raw_dev="`echo ${raw_dev} | sed 's|/dev/||'`"
+
+# Check if interactive mode will be used
+if [ -n "$INTERACTIVE_MODE" ] && [ "$INTERACTIVE_MODE" -eq 1 ]; then
+	if [ -z "$ARTIFACTS_DIR" ] || [ ! -d "$ARTIFACTS_DIR" ]; then
+		ARTIFACTS_DIR=$IMAGESDIR
+	fi
+	debugmsg ${DEBUG_INFO} "Entering interactive mode..."
+	SAVE_CONFIG_FOLDER="saved_config"
+	tmpconf="${SAVE_CONFIG_FOLDER}/config.sh"
+	echo "" > ${tmpconf}
+	tmppuppet=${SAVE_CONFIG_FOLDER}/puppet/init.pp
+	recursive_mkdir ${SAVE_CONFIG_FOLDER}/puppet
+	echo "" > $tmppuppet
+	promptsdir=${LIBDIR}/prompts
+	INSTALL_TYPE=full
+	for f in `ls $promptsdir`; do
+		source $promptsdir/$f
+		basename=${f%.*}
+		${basename:5}
+		if [ $? -ne 0 ]; then
+			debugmsg ${DEBUG_CRIT} -e "\n\n\nFailed to generate config using interactive mode, run again or specify a config via --config option."
+			exit 1
+		fi
+	done
+
+	debugmsg ${DEBUG_INFO} -e "\n\n\nUser config saved. Installation will continue."
+	debugmsg ${DEBUG_INFO} "You can specify --config ${SAVE_CONFIG_FOLDER}/config.sh option in your later installations to use the exact same configurations."
+	CONFIG_FILES="`pwd`/${SAVE_CONFIG_FOLDER}/config.sh"
+	source $CONFIG_FILES
+fi
 
 if [ ! -d "${IMAGESDIR}" ]; then
     if [ -n "${ARTIFACTS_DIR}" ]; then
@@ -273,23 +330,6 @@ if [ -z "${privilegedcn}" ]; then
         privilegedcn="cube-desktop"
     fi
 fi
-
-## typical qemu disk is vdb
-rootfs=$1
-raw_dev=$2
-
-if [ -e "$rootfs" ]; then
-    rootfs=`readlink -f $rootfs`
-else
-    if [ ! -f "${IMAGESDIR}/$rootfs" ]; then
-	debugmsg ${DEBUG_CRIT} "[ERROR]: install rootfs ($rootfs) not found"
-	exit 1
-    fi
-    rootfs="${IMAGESDIR}/$rootfs"
-fi
-
-# remove /dev/ if specified
-raw_dev="`echo ${raw_dev} | sed 's|/dev/||'`"
 
 # create partitions
 # 
@@ -879,6 +919,9 @@ smart update"
 
 fi
 
+if [ -d "$CURRENTDIR/$PUPPETDIR" ]; then
+	PUPPETDIR=$CURRENTDIR/$PUPPETDIR
+fi
 if [ -d ${PUPPETDIR} ]; then
 	debugmsg ${DEBUG_INFO} "[INFO]: Running puppet"
 	cd ${TMPMNT}

--- a/lib/prompts/0001_distro_config.sh
+++ b/lib/prompts/0001_distro_config.sh
@@ -1,0 +1,23 @@
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2 as
+#  published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+
+# Distribution related prompts
+
+distro_config()
+{
+	local tmpfile=$(mktemp)
+	dialog --no-cancel --inputbox "Distribution name:" 8 40 "OverC" 2>$tmpfile
+	dialog_res=$(cat $tmpfile)
+	if [ -n "${dialog_res}" ]; then
+		echo "DISTRIBUTION=\"${dialog_res}\"" >> ${tmpconf}
+	else
+		echo "DISTRIBUTION=\"OverC\"" >> ${tmpconf}
+	fi
+	rm $tmpfile
+}

--- a/lib/prompts/0002_artifacts_config.sh
+++ b/lib/prompts/0002_artifacts_config.sh
@@ -1,0 +1,145 @@
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2 as
+#  published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+
+# Artifacts related prompts
+
+artifacts_config()
+{
+	local tmpfile=$(mktemp)
+	local filecount=0
+	local filelist=""
+
+	if [ -z "$ARTIFACTS_DIR" ]; then
+		if [ -e "images" ]; then
+			ARTIFACTS_DIR="`pwd`/images"
+		else
+			# default to current dir
+			ARTIFACTS_DIR="`pwd`"
+		fi
+	fi
+
+	echo "ARTIFACTS_DIR=\"${ARTIFACTS_DIR}\"" >> ${tmpconf}
+	filecount=`ls $ARTIFACTS_DIR -1 | grep -v manifest | wc -l`
+	if [ $filecount -lt 3 ]; then
+		debugmsg ${DEBUG_CRIT} "Artifacts are not sufficient. Please verify."
+		return 1
+	fi
+
+	# Kernel selection
+	filelist=`ls $ARTIFACTS_DIR | grep -E "(.*[uz]Image.*)|(.*vmlinu[xz].*)"`
+	if [ -z "$filelist" ]; then
+		debugmsg ${DEBUG_CRIT} "Kernel file not found. Please specify the correct artifacts dir."
+		return 1
+	fi
+	format_menuitems "$filelist"
+	filecount=$?
+	dialog --no-tags --menu "Please choose kernel:" \
+		$(expr $filecount + 7) 100 $filecount $menuitems 2>$tmpfile
+	dialog_res=$(cat $tmpfile)
+	if [ -z "${dialog_res}" ]; then
+		debugmsg ${DEBUG_CRIT} "Kernel not specified. Please try again."
+		return 1
+	fi
+	echo "INSTALL_KERNEL=\"\${ARTIFACTS_DIR}/${dialog_res}\"" >> ${tmpconf}
+
+	# Initramfs selection
+	filelist=`ls $ARTIFACTS_DIR | grep initramfs | grep -v manifest`
+	format_menuitems "$filelist"
+	filecount=$?
+	dialog --no-tags --menu "Please choose initramfs:" \
+		$(expr $filecount + 7) 100 $filecount $menuitems 2>$tmpfile
+	dialog_res=$(cat $tmpfile)
+	if [ -z "${dialog_res}" ]; then
+		debugmsg ${DEBUG_CRIT} "Initramfs not specified. Please try again."
+		return 1
+	fi
+	echo "INSTALL_INITRAMFS=\"\${ARTIFACTS_DIR}/${dialog_res}\"" >> ${tmpconf}
+
+	# Rootfs selection
+	filelist=`ls $ARTIFACTS_DIR | grep essential | grep -v manifest`
+	format_menuitems "$filelist"
+	filecount=$?
+	dialog --no-tags --menu "Please choose rootfs:" \
+		$(expr $filecount + 7) 100 $filecount $menuitems 2>$tmpfile
+	dialog_res=$(cat $tmpfile)
+	if [ -z "${dialog_res}" ]; then
+		debugmsg ${DEBUG_CRIT} "Rootfs not specified. Please try again."
+		return 1
+	fi
+	echo "INSTALL_ROOTFS=\"\${ARTIFACTS_DIR}/${dialog_res}\"" >> ${tmpconf}
+	echo "HDINSTALL_ROOTFS=\"\${ARTIFACTS_DIR}/${dialog_res}\"" >> ${tmpconf}
+
+	# containers selection
+	if [ -d "$ARTIFACTS_DIR/containers" ]; then
+		filelist=`ls $ARTIFACTS_DIR/containers`
+	else
+		filelist=`ls $ARTIFACTS_DIR | grep tar`
+	fi
+	format_menuitems "$filelist" off
+	filecount=$?
+	dialog --no-tags --checklist "Please choose install containers:" \
+		$(expr $filecount + 7) 100 $filecount $menuitems 2>$tmpfile
+	dialog_res=$(cat $tmpfile)
+	if [ -z "${dialog_res}" ]; then
+		debugmsg ${DEBUG_CRIT} "Containers not specified. Please try again."
+		return 1
+	fi
+
+	hdcontainers=${dialog_res} fmtcontainers=""
+
+	# VT and network prime selection
+	menuitems=""
+	filecount=0
+	for i in ${hdcontainers}; do
+		if [ -d "$ARTIFACTS_DIR/containers" ]; then
+			fmtcontainers="$fmtcontainers containers/$i"
+		else
+			fmtcontainers="$fmtcontainers $i"
+		fi
+		menuitems="$menuitems $i $i"
+		dialog --yesno "Do you want to allocate a virtual console for $i?" 10 100
+		if [ $? -eq 0 ]; then
+			fmtcontainers="$fmtcontainers:console"
+			dialog --inputbox "Which virtual terminal to be allocated to $i:" 8 100 2>$tmpfile
+			dialog_res=$(cat $tmpfile)
+
+			# TODO: sanity check
+			if [ -n "${dialog_res}" ]; then
+				fmtcontainers="$fmtcontainers:vty=${dialog_res}"
+			fi
+		fi
+		let filecount++
+	done
+	dialog --no-tags --menu "Please choose the network prime container:" \
+		$(expr $filecount + 7) 100 $filecount $menuitems 2>$tmpfile
+	network_prime_container=$(cat $tmpfile)
+	if [ -z "${network_prime_container}" ]; then
+		debugmsg ${DEBUG_INFO} "Network prime containers not specified."
+	else
+		# Define network device
+		dialog --inputbox "Please provide the network device to be used in the network prime container:" 8 100 "all" 2>$tmpfile
+		dialog_res=$(cat $tmpfile)
+		if [ -n "$dialog_res" ]; then
+			echo "NETWORK_DEVICE=\"${dialog_res}\"" >> ${tmpconf}
+		fi
+	fi
+
+	# Format HDINSTALL_CONTAINERS configuration
+	echo "HDINSTALL_CONTAINERS=\" \\" >> ${tmpconf}
+	for i in ${fmtcontainers}; do
+		echo -n " \${ARTIFACTS_DIR}/${i}" >> ${tmpconf}
+		if [[ $i == *${network_prime_container}* ]]; then
+			echo -n ":net=1" >> ${tmpconf}
+		fi
+		echo " \\" >> ${tmpconf}
+	done
+	echo " \"" >> ${tmpconf}
+
+	rm $tmpfile
+}

--- a/lib/prompts/0003_partition_config.sh
+++ b/lib/prompts/0003_partition_config.sh
@@ -1,0 +1,173 @@
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2 as
+#  published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+
+# Partition related prompts
+
+partition_config()
+{
+	local tmpfile=$(mktemp)
+	# define if this is an installer image
+	# If this is an installer image, we provide only two partitions for user to choose.
+	# If this is an live/harddrive image, we provide four partitions for user to configure.
+	local lastsize=0
+	local tmppartitionlayout="${SAVE_CONFIG_FOLDER}/fdisk-4-partition-user-layout.txt"
+	local size=0
+
+	if [ -z "$target" ] && [ -n "$raw_dev" ]; then
+		target=$raw_dev
+	fi
+	if [ -z "$TARGET_TYPE" ]; then
+		if [ -e "/sys/block/$(basename "$target")" ]; then
+			TARGET_TYPE=block
+		elif [ -d $target ]; then
+			TARGET_TYPE=dir
+		else
+			TARGET_TYPE=image
+		fi
+	fi
+	case $TARGET_TYPE in
+		block)
+			size=`blockdev --getsize64 /dev/$(basename "$target")`
+			;;
+		image)
+			# prompt for target size if not defined
+			if [ -z "$TARGET_DISK_SIZE" ]; then
+				dialog --inputbox "Please input the size of the image file:" 8 100 "7G" 2>$tmpfile
+				size=$(cat $tmpfile)
+				if [ -z "$size" ]; then
+					debugmsg ${DEBUG_INFO} "Image size not provided. Will use 7G as default."
+					echo "TARGET_DISK_SIZE=\"7G\"" >> ${tmpconf}
+					size=7516192768
+				else
+					echo "TARGET_DISK_SIZE=\"$size\"" >> ${tmpconf}
+					size=`numfmt --from=iec $size`
+				fi
+			else
+				size=`numfmt --from=iec $TARGET_DISK_SIZE`
+			fi
+			;;
+	esac
+
+	if [ -z "$INSTALL_TYPE" ]; then
+		if [ "$TARGET_TYPE" == block ]; then
+			INSTALL_TYPE=installer
+		else
+			INSTALL_TYPE=full
+		fi
+	fi
+
+	local prompt="Destinition device will be partitioned using the following schema: \n"
+	if [ "$INSTALL_TYPE" == "installer" ]; then
+		lastsize=`numfmt --to=iec --round=down $(expr $size - 268435456)`
+		prompt="$prompt 1) boot (250M) \n 2) root ($lastsize)"
+	else
+		containerpartsize=`numfmt --to=iec --round=down $(expr $size - 3221225472)`
+		prompt="$prompt 1) boot (250M) \n 2) swap (768M) \n 3) root (2G) \n 4) containers ($containerpartsize)"
+	fi
+	dialog --yesno "$prompt" 10 80
+	dialog_res=$?
+	if [ $dialog_res -eq 0 ]; then
+		# User answered yes. Just use default
+		if [ "$INSTALL_TYPE" == "installer" ]; then
+			bootpartsize="250M"
+			rootfspartsize="-1"
+		else
+			bootpartsize="250M"
+			swappartsize="768M"
+			rootfspartsize="2048M"
+		fi
+	else
+		# User answered no. Prompt for sizes.
+		# TODO:
+		#   1.Let user do manual partition layout
+		#   2.Do value sanity check
+		if [ "$INSTALL_TYPE" == "installer" ]; then
+			dialog --no-cancel --inputbox "Boot partition size:" 8 40 "250M" 2>$tmpfile
+			bootpartsize=`numfmt --from=iec $(cat $tmpfile)`
+			lastsize=`numfmt --to=iec $(expr $size - ${bootpartsize} - 2097152)`
+			dialog --no-cancel --inputbox "Rootfs partition size:" 8 40 "${lastsize}" 2>$tmpfile
+			rootfspartsize=$(cat $tmpfile)
+		else
+			dialog --no-cancel --inputbox "Boot partition size:" 8 40 "250M" 2>$tmpfile
+			bootpartsize=`numfmt --from=iec $(cat $tmpfile)`
+			dialog --no-cancel --inputbox "Swap partition size:" 8 40 "768M" 2>$tmpfile
+			swappartsize=`numfmt --from=iec $(cat $tmpfile)`
+			dialog --no-cancel --inputbox "Rootfs partition size:" 8 40 "2G" 2>$tmpfile
+			rootfspartsize=`numfmt --from=iec $(cat $tmpfile)`
+			dialog --no-cancel --inputbox "Containers partition size:" 8 40 \
+				"`numfmt --to=iec --round=down $(expr $size - ${bootpartsize} - ${swappartsize} - ${rootfspartsize} - 2097152)`" 2>$tmpfile
+			containerpartsize=$(cat $tmpfile)
+		fi
+	fi
+	if [ "$INSTALL_TYPE" == "installer" ]; then
+		echo "BOOTPART_START=\"63s\"" >> ${tmpconf}
+		echo "BOOTPART_END=\"${bootpartsize}\"" >> ${tmpconf}
+		echo "BOOTPART_FSTYPE=\"fat32\"" >> ${tmpconf}
+		echo "BOOTPART_LABEL=\"OVERCBOOT\"" >> ${tmpconf}
+		echo "ROOTFS_START=\"${bootpartsize}\"" >> ${tmpconf}
+		if [ ${rootfspartsize} == "-1" ]; then
+			echo "ROOTFS_END=\"${rootfspartsize}\"" >> ${tmpconf}
+		else
+			echo "ROOTFS_END=\"$(expr `numfmt --from=iec $bootpartsize` + `numfmt --from=iec $rootfspartsize`)\"" >> ${tmpconf}
+		fi
+		echo "ROOTFS_FSTYPE=\"ext2\"" >> ${tmpconf}
+		echo "ROOTFS_LABEL=\"OVERCINSTROOTFS\"" >> ${tmpconf}
+	else
+		cat <<EOF > ${tmppartitionlayout}
+d
+1
+d
+2
+d
+3
+d
+4
+
+
+n
+p
+1
+
++`numfmt --to=iec --from=iec ${bootpartsize}`
+n
+p
+2
+
++`numfmt --to=iec --from=iec ${swappartsize}`
+n
+p
+3
+
++`numfmt --to=iec --from=iec ${rootfspartsize}`
+n
+p
+
++`numfmt --to=iec --from=iec --round=down ${containerpartsize}`
+a
+1
+t
+1
+b
+t
+2
+82
+t
+3
+83
+w
+p
+q
+
+
+EOF
+		echo "FDISK_PARTITION_LAYOUT=\"${tmppartitionlayout}\"" >> ${tmpconf}
+	fi
+
+	rm $tmpfile
+}

--- a/lib/prompts/0004_user_config.sh
+++ b/lib/prompts/0004_user_config.sh
@@ -1,0 +1,48 @@
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2 as
+#  published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+
+# User related prompts
+
+user_config()
+{
+	local tmpfile=$(mktemp)
+	# Add new user
+	dialog --no-cancel --inputbox "Create new user(leave blank if not wanted):" 8 60 2>$tmpfile
+	username=$(cat $tmpfile)
+	if [ -n "$username" ]; then
+		passwd1="" passwd2="" passwdprompt="Please input password:"
+		while [ -z "$passwd1" ] || [ -z "$passwd2" ] || [ "$passwd1" != "$passwd2" ]; do
+			dialog --no-cancel --inputbox "$passwdprompt" 8 40 2>$tmpfile
+			passwd1=$(cat $tmpfile)
+			dialog --no-cancel --inputbox "Please confirm password:" 8 40 2>$tmpfile
+			passwd2=$(cat $tmpfile)
+			passwdprompt="Password mismatch! Please re-input password:"
+		done
+		cryptpasswd=$(python -c "import crypt; print crypt.crypt(\"$passwd1\", \"\$6\$\")")
+		cat <<EOF >> ${tmppuppet}
+group { "$username":
+	name => "$username",
+	ensure => present,
+}
+
+user { "$username":
+	ensure => present,
+	gid => "$username",
+	groups => ["users"],
+	membership => minimum,
+	shell => "/bin/bash",
+	require => [Group["$username"]],
+	password => '$cryptpasswd',
+}
+
+EOF
+	fi
+
+	rm $tmpfile
+}

--- a/lib/prompts/0005_timezone_config.sh
+++ b/lib/prompts/0005_timezone_config.sh
@@ -1,0 +1,50 @@
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2 as
+#  published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+
+# Timezone related prompts
+
+timezone_config()
+{
+	local tmpfile=$(mktemp)
+	tzinfo="/usr/share/zoneinfo"
+	while [ ! -f "$tzinfo" ]; do
+		if [ "$tzinfo" != "/usr/share/zoneinfo" ]; then
+			menuitems=".. .."
+		else
+			menuitems=""
+		fi
+		filecount=0
+		for i in `ls -1 ${tzinfo}`; do
+			menuitems="$menuitems $i $i"
+			let filecount++
+		done
+		dialog --no-tags --menu "Select your time zone:" \
+			$(expr $filecount + 7) 100 $filecount $menuitems 2>$tmpfile
+		dialog_res=$(cat $tmpfile)
+		if [ "$dialog_res" == ".." ]; then
+			tzinfo=`dirname $tzinfo`
+		elif [ -n "$dialog_res" ]; then
+			tzinfo="$tzinfo/$dialog_res"
+		fi
+	done
+	tzinfo=${tzinfo:20}
+	cat <<EOF >> ${tmppuppet}
+exec { 'set_localtime':
+	command => "/bin/ln -sf /usr/share/zoneinfo/${tzinfo} /etc/localtime",
+}
+file { 'timezone':
+path => "/etc/timezone",
+content => "${tzinfo}",
+}
+
+EOF
+
+
+	rm $tmpfile
+}

--- a/lib/prompts/9999_base_config.sh
+++ b/lib/prompts/9999_base_config.sh
@@ -1,0 +1,51 @@
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2 as
+#  published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+
+# Base config, currently no prompts yet. To be added later if required.
+
+base_config()
+{
+	cat <<EOF >> ${tmpconf}
+EVAL_NAME="OverC Evaluation"
+
+HARDDRIVE_BANNER="Wind River Hard Drive Installer
+--------------------------------------------------------------------------------
+\$EVAL_NAME
+--------------------------------------------------------------------------------"
+
+HARDDRIVE_INTRODUCTION="
+This installer will erase all data on your hard drive and configure it to boot
+a working Nucleo-T
+"
+
+USBSTORAGE_BANNER="USB Creator for the Hard Drive Installer
+--------------------------------------------------------------------------------
+\$EVAL_NAME
+--------------------------------------------------------------------------------"
+
+USBSTORAGE_INTRODUCTION="
+This script will erase all data on your USB flash drive and configure it to boot
+the Wind River Hard Drive Installer.  This installer will then allow you to
+install a working system configuration on to your internal hard drive.
+"
+
+INSTALLER_COMPLETE="Installation is now complete"
+
+CMD_GRUB_INSTALL=\`which grub-install\`
+
+INSTALL_GRUBHDCFG="grub-hd.cfg"
+INSTALL_GRUBUSBCFG="grub-usb.cfg"
+INSTALL_GRUBCFG="\${INSTALLER_FILES_DIR}/\${INSTALL_GRUBUSBCFG}"
+INSTALL_FILES="\${INSTALL_KERNEL} \${INSTALL_ROOTFS} \${INSTALL_MODULES} \${INSTALL_GRUBCFG}"
+PREREQ_FILES="\${INSTALL_FILES} \${HDINSTALL_ROOTFS} \`strip_properties \${HDINSTALL_CONTAINERS}\`"
+
+CONFIRM_REBOOT=0
+
+EOF
+}

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -9,13 +9,28 @@
 #  See the GNU General Public License for more details.
 export PATH="$PATH:/bin"
 
-BASEDIR=$(dirname $BASH_SOURCE)
-
 if [ "$CUBE_DEBUG_SET_X_IF_SET" = 1 ] ; then
     set -x
 fi
 
+BASEDIR=$(dirname $BASH_SOURCE)
+# support files
+INSTALLER_FILES_DIR="${BASEDIR}/../files"
+# sbin files (typically this creator)
+SBINDIR="${BASEDIR}/../sbin"
+# installers that will go on the usb stick, and install to the HD
+INSTALLERS_DIR="${BASEDIR}/../installers"
+LIBDIR="${BASEDIR}/../lib"
+
 : ${FUNCTIONS_FILE="$BASEDIR/functions.sh"}
+
+## Load functions file
+if ! [ -e $FUNCTIONS_FILE ]
+then
+	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
+	exit 1
+fi
+source $FUNCTIONS_FILE
 
 usage()
 {
@@ -33,6 +48,7 @@ cat << EOF
   options:
 
      --config <script>: use the specified configuration script found in ~/.overc/
+     -i or --interactive: use the interactive configuration interface
      --target-config <script>: use the specified configuration script found in ~/.overc/
                                when running the target installer
      --force: force overwrite any output files or images
@@ -101,6 +117,13 @@ while [ $# -gt 0 ]; do
 	    TARGET_DISK_SIZE="$2"
 	    shift
 	    ;;
+	--interactive|-i)
+		# Interactive config mode
+		INTERACTIVE_MODE=1
+		for app in blockdev dialog; do
+			verify_utility $app || { echo >&2 "ERROR: $app is not available"; exit 1; }
+		done
+		;;
     --installer)
 	    # create an installer, not a final image (this is the default)
             INSTALLER_IMAGE=t
@@ -127,12 +150,6 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-# support files
-INSTALLER_FILES_DIR="${BASEDIR}/../files"
-# sbin files (typically this creator)
-SBINDIR="${BASEDIR}/../sbin"
-# installers that will go on the usb stick, and install to the HD
-INSTALLERS_DIR="${BASEDIR}/../installers"
 # configuration for this script
 if [ -z "${CONFIG_DIRS}" ] ; then
     CONFIG_DIRS="${BASEDIR}/../config $HOME/.overc/"
@@ -145,14 +162,6 @@ if [ -n "$ARTIFACTS_DIR" ]; then
     fi
 fi
 export ARTIFACTS_DIR
-
-## Load functions file
-if ! [ -e $FUNCTIONS_FILE ]
-then
-	echo "ERROR: Could not find function definitions (${FUNCTIONS_FILE})"
-	exit 1
-fi
-source $FUNCTIONS_FILE
 
 ######################################################################
 # Define some debug output variables
@@ -196,11 +205,6 @@ if [ "$TARGET_TYPE" = "block" ]; then
 fi
 
 ## Load configuration file(s)
-if [ -z ${CONFIG_FILES} ]; then
-    echo "ERROR: no configuration was provided via --config"
-    exit 1
-fi
-
 colon_separated_config_dirs=`echo ${CONFIG_DIRS} | sed 's/ /:/g'`
 for config in ${CONFIG_FILES}; do
     config_to_source="${config}"
@@ -235,6 +239,41 @@ if [ "${#ROOTFS_LABEL}" -gt 16 ]; then
 	fi
 fi
 
+# Check if interactive mode will be used
+if [ -z ${CONFIG_FILES} ] || ([ -n "$INTERACTIVE_MODE" ] && [ "$INTERACTIVE_MODE" -eq 1 ]); then
+	if [ -z "$ARTIFACTS_DIR" ]; then
+		debugmsg ${DEBUG_CRIT} -e "Artifacts dir not found, please use --artifacts to specify."
+		exit 1
+	fi
+	debugmsg ${DEBUG_INFO} "Entering interactive mode..."
+	SAVE_CONFIG_FOLDER="saved_config"
+	tmpconf="${SAVE_CONFIG_FOLDER}/config.sh"
+	echo "" > ${tmpconf}
+	tmppuppet=${SAVE_CONFIG_FOLDER}/puppet/init.pp
+	recursive_mkdir ${SAVE_CONFIG_FOLDER}/puppet
+	echo "" > $tmppuppet
+	promptsdir=${LIBDIR}/prompts
+	for f in `ls $promptsdir`; do
+		source $promptsdir/$f
+		basename=${f%.*}
+		${basename:5}
+		if [ $? -ne 0 ]; then
+			debugmsg ${DEBUG_CRIT} -e "\n\n\nFailed to generate config using interactive mode, run again or specify a config via --config option."
+			exit 1
+		fi
+	done
+
+	# enable puppet
+	echo "PUPPETDIR=\"${SAVE_CONFIG_FOLDER}/puppet\"" >> ${tmpconf}
+	echo "INSTALL_PUPPET_DIR=\"${SAVE_CONFIG_FOLDER}/puppet\"" >> ${tmpconf}
+
+	debugmsg ${DEBUG_INFO} -e "\n\n\nUser config saved. Installation will continue."
+	debugmsg ${DEBUG_INFO} "You can specify --config ${SAVE_CONFIG_FOLDER}/config.sh option in your later installations to use the exact same configurations."
+	CONFIG_FILES="`pwd`/${SAVE_CONFIG_FOLDER}/config.sh"
+	TARGET_CONFIG_FILE=$CONFIG_FILES
+	source $CONFIG_FILES
+fi
+
 if ! [ -n "$DISTRIBUTION" ]; then
     DISTRIBUTION="OverC"
 fi
@@ -256,6 +295,7 @@ if [ -z "${INSTALLER_TARGET_DIR}" ]; then
     INSTALLER_TARGET_DIR="/opt/installer"
 fi
 INSTALLER_TARGET_SBIN_DIR="${INSTALLER_TARGET_DIR}/sbin"
+INSTALLER_TARGET_LIB_DIR="${INSTALLER_TARGET_DIR}/lib"
 INSTALLER_TARGET_CONFIG_DIR="${INSTALLER_TARGET_DIR}/config"
 INSTALLER_TARGET_FILES_DIR="${INSTALLER_TARGET_DIR}/files"
 INSTALLER_TARGET_IMAGES_DIR="${INSTALLER_TARGET_DIR}/images"
@@ -389,6 +429,15 @@ custom_install_rules()
 	    assert_return $?
 	else
 	    debugmsg ${DEBUG_INFO} "No kernel modules specified, not extracting"
+	fi
+
+	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_LIB_DIR}
+	assert_return $?
+
+	cp -r ${LIBDIR}/* ${mnt_rootfs}${INSTALLER_TARGET_LIB_DIR}
+	if [ $? -ne 0 ]; then
+		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy lib files"
+		return 1
 	fi
 
 	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_SBIN_DIR}
@@ -527,9 +576,12 @@ IFS=$OLDIFS
 	# puppet modules etc.
 	if [ -v INSTALL_PUPPET_DIR ]; then
 	    if [ -d ${INSTALLER_FILES_DIR}/${INSTALL_PUPPET_DIR} ]; then
-		debugmsg ${DEBUG_INFO} "Copying Puppet files to install media"
-		recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/puppet
-		cp -r ${INSTALLER_FILES_DIR}/${INSTALL_PUPPET_DIR}/* ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/puppet/
+			INSTALL_PUPPET_DIR=${INSTALLER_FILES_DIR}/${INSTALL_PUPPET_DIR}
+		fi
+		if [ -d ${INSTALL_PUPPET_DIR} ]; then
+			debugmsg ${DEBUG_INFO} "Copying Puppet files to install media"
+			recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/puppet
+			cp -r ${INSTALL_PUPPET_DIR}/* ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/puppet/
 	    else
 		debugmsg ${DEBUG_INFO} "INSTALL_PUPPET_DIR set but directory doesn't exist."
 	    fi

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -1081,3 +1081,20 @@ installer_main()
 		confirm_reboot
 	fi
 }
+
+# make menuitems function
+# param #1: the item list
+# param #2: optional. If present, it will be regarded as the checklist default status
+# return: the item count
+format_menuitems()
+{
+	menuitems=""
+	local itemlist=$1
+	local checklistswitch=$2
+	local itemcount=0
+	for i in $itemlist; do
+		menuitems="$menuitems $i $i $checklistswitch"
+		let itemcount++
+	done
+	return $itemcount
+}


### PR DESCRIPTION
v3: update PR to make sure partition related changes are there. Tested with Intel x86 image.

Currently user must define a configuration file to lead the
installation process. In order to reduce the learning complexity of the
configuration items, we introduce this interactive process to guide the
user to generate a configuration file and use that during the following
installation process.

This interactive process is triggered if no configuration file is
provided through the commandline or if interactive parameter
--interactive or -i is specifically provided through commandline.

The generated configuration file can be reused later by passing through
the --config parameter.

Signed-off-by: Feng Mu Feng.Mu@windriver.com
