### PR TITLE
storage-encryption: support rootfs encryption

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -78,6 +78,7 @@ cat << EOF
     --ttyconsoledev: set dev used for tty console
     --ttyconsolecn: set container name for providing agetty
     --privilegedcn: set container name for privileged
+    --encrypt: encrypt the rootfs
 
 EOF
 }
@@ -90,6 +91,7 @@ fi
 btrfs=0
 ttyconsolecn=""
 ttyconsoledev="ttyS0"
+do_encryption=0
 while [ $# -gt 0 ]; do
     case "$1" in
     --config) 
@@ -130,6 +132,9 @@ while [ $# -gt 0 ]; do
     --partition_layout)
             FDISK_PARTITION_LAYOUT_INPUT="$2"
             shift
+            ;;
+    --encrypt)
+            do_encryption=1
             ;;
          *) break
             ;;
@@ -239,6 +244,22 @@ fi
 
 if [ -v CONTAINER_PREFIX -a -n "$CONTAINER_PREFIX" ] ; then
     export CNAME_PREFIX="--prefix $CONTAINER_PREFIX"
+fi
+
+if [ $do_encryption -eq 1 ] ; then
+    which luks-setup.sh >/dev/null 2>&1
+    if [ $? -eq 1 ]; then
+        echo "WARNING: --encrypt ignored due to missing luks-setup.sh. \
+Install cryptfs-tpm2"
+        do_encryption=0
+    fi
+
+    which cryptsetup >/dev/null 2>&1
+    if [ $? -eq 1 ]; then
+        echo "WARNING: --encrypt ignored due to missing cryptsetup. \
+Install cryptsetup"
+        do_encryption=0
+    fi
 fi
 
 get_container_name_by_prop()
@@ -398,6 +419,12 @@ mkfs.vfat -I -n $BOOTLABEL /dev/${fs_dev}1
 ## define the device file names for rootfs and lxc filesystem
 rootfs_dev=${fs_dev}3
 lxc_fs_dev=${fs_dev}4
+
+if [ $do_encryption -eq 1 ]; then
+    ## Evict all objects for the first creation.
+    luks-setup.sh -f -e -d /dev/${rootfs_dev} -n "${ROOTLABEL}_encrypted"
+    rootfs_dev="mapper/${ROOTLABEL}_encrypted"
+fi
 
 if [ $btrfs -eq 0 ]; then
     debugmsg ${DEBUG_INFO} "[INFO]: creating / (ext4)"
@@ -1000,7 +1027,13 @@ else
 fi
 
 rmdir ${TMPMNT}
-	
+
+if [ $do_encryption -eq 1 ]; then
+    echo "INFO: Closing LUKS ..."
+
+    cryptsetup luksClose "${ROOTLABEL}_encrypted"
+fi
+
 # don't run this on a host!!
 # sync ; sync ; echo 3> /proc/sys/vm/drop_caches
 # echo o > /proc/sysrq-trigger

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -394,17 +394,22 @@ mkswap -L $SWAPLABEL /dev/${fs_dev}2
 set -e
 debugmsg ${DEBUG_INFO} "[INFO]: creating /boot (vfat)"
 mkfs.vfat -I -n $BOOTLABEL /dev/${fs_dev}1
+
+## define the device file names for rootfs and lxc filesystem
+rootfs_dev=${fs_dev}3
+lxc_fs_dev=${fs_dev}4
+
 if [ $btrfs -eq 0 ]; then
     debugmsg ${DEBUG_INFO} "[INFO]: creating / (ext4)"
-    mkfs.ext4 -v -L $ROOTLABEL /dev/${fs_dev}3
-    mkfs.ext4 -v -L $LXCLABEL /dev/${fs_dev}4
+    mkfs.ext4 -v -L $ROOTLABEL /dev/${rootfs_dev}
+    mkfs.ext4 -v -L $LXCLABEL /dev/${lxc_fs_dev}
 else
     debugmsg ${DEBUG_INFO} "[INFO]: creating / (btrfs)"
     set +e
     has_f=`mkfs.btrfs 2>&1 |grep -q '^.*\-f' && echo -f`
     set -e
-    mkfs.btrfs $has_f -L $ROOTLABEL /dev/${fs_dev}3
-    mkfs.btrfs $has_f -L $LXCLABEL /dev/${fs_dev}4
+    mkfs.btrfs $has_f -L $ROOTLABEL /dev/${rootfs_dev}
+    mkfs.btrfs $has_f -L $LXCLABEL /dev/${lxc_fs_dev}
 fi
 set +e
 
@@ -413,7 +418,7 @@ if [ -z "${TMPMNT}" ]; then
     export TMPMNT
 fi
 mkdir -p ${TMPMNT}
-mount /dev/${fs_dev}3 ${TMPMNT}
+mount /dev/${rootfs_dev} ${TMPMNT}
 
 if [ $btrfs -eq 0 ]; then
 	mkdir ${TMPMNT}/boot
@@ -495,7 +500,7 @@ if [ $btrfs -eq 1 ]; then
 	sync
 	umount ${TMPMNT}/rootfs/mnt
 	umount ${TMPMNT}/
-	mount -o subvolid=${subvol} /dev/${fs_dev}3 ${TMPMNT}
+	mount -o subvolid=${subvol} /dev/${rootfs_dev} ${TMPMNT}
 	mount /dev/${fs_dev}1 ${TMPMNT}/mnt
 	cd ${TMPMNT}/
 fi
@@ -658,7 +663,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
     if [ ! -d ${TMPMNT}/var/lib/lxc ]; then
         mkdir -p ${TMPMNT}/var/lib/lxc
     fi
-    mount /dev/${fs_dev}4 ${TMPMNT}/var/lib/lxc
+    mount /dev/${lxc_fs_dev} ${TMPMNT}/var/lib/lxc
 
     mkdir -p ${TMPMNT}/tmp
 
@@ -668,7 +673,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
         subvol=`btrfs subvolume list ${TMPMNT}/var/lib/lxc | awk '{print $2;}'`
         sync
         umount ${TMPMNT}/var/lib/lxc
-        mount -o subvol=workdir /dev/${fs_dev}4 ${TMPMNT}/var/lib/lxc
+        mount -o subvol=workdir /dev/${lxc_fs_dev} ${TMPMNT}/var/lib/lxc
     fi
 
     # deal with static IPs and the "Networking Prime"
@@ -922,7 +927,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
         if [ -z "$subvol" ]; then
             debugmsg ${DEBUG_WARN} "[WARNING]: Could not get subvolume id, thus cannot create factory reset snapshot"
         else
-            mount /dev/${fs_dev}4 ${TMPMNT}/var/lib/lxc
+            mount /dev/${lxc_fs_dev} ${TMPMNT}/var/lib/lxc
             btrfs subvolume set-default $subvol ${TMPMNT}/var/lib/lxc
             btrfs subvolume snapshot ${TMPMNT}/var/lib/lxc/workdir ${TMPMNT}/var/lib/lxc/${FACTORY_SNAPSHOT}
             #snapshot subvolume recursively
@@ -981,7 +986,7 @@ if [ $btrfs -eq 0 ]; then
 else
 	debugmsg ${DEBUG_INFO} "[INFO]: Creating a snapshot of rootfs for recovery."
 	#mount the root subvolume
-	mount -o subvolid=5 /dev/${fs_dev}3 ${TMPMNT}
+	mount -o subvolid=5 /dev/${rootfs_dev} ${TMPMNT}
 	if [ -e "${TMPMNT}/rootfs" ]; then
 		btrfs subvolume snapshot ${TMPMNT}/rootfs ${TMPMNT}/rootfs_bakup
 		btrfs subvolume snapshot ${TMPMNT}/rootfs ${TMPMNT}/${FACTORY_SNAPSHOT}

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -606,6 +606,13 @@ install_grub()
 	    ${CMD_GRUB_INSTALL} --root-directory=${mountpoint} --no-floppy hd0 # > /dev/null 2>&1
 	else
 	    ${CMD_GRUB_INSTALL} --root-directory=${mountpoint} --no-floppy --recheck /dev/${device} # > /dev/null 2>&1
+	    # Fedora 24 employs grub2-install which installs the files to DIR/grub2
+	    if [ -d "${mountpoint}/boot/grub2" ]; then
+		if ! mv "${mountpoint}/boot/grub2" "${mountpoint}/boot/grub"; then
+		    debugmsg ${DEBUG_CRIT} "ERROR: Unable to rename ${mountpoint}/boot/grub2"
+		    return 1
+		fi
+	    fi
 	fi
 	if [ $? -ne 0 ]
 	then


### PR DESCRIPTION
Basically, the rootfs encryption is created during runtime, with specifying
--encrypt option in cubeit-installer. Due to the necessity of TPM 2.0 chip,
this process can only occur with overc installer runtime on target.

After the creation, the essential rootfs on a hard drive will be mounted before
the decryption and the decryption occurs in initramfs. More specifically, a
dedicated script called /init.cryptfs is launched by /init, if the rootfs device
specified in kernel cmdline is unable to be mounted. This is expected 'cause kernel
doesn't have knowledge about how a LUKS partition is parsed. With the assist  of
init.cryptfs, the passphrase used to decrypt the rootfs is unsealed from TPM
and then the encrypted rootfs is mapped to /dev/mapper/xxx which works as a real
rootfs device. Eventually, switch_root will call /sbin/init from the mapped
rootfs device in order to change to the real rootfs.

The entire mount operation is transparent to the end user. 