### PR TITLE
cubeit-installer: use 'dos' instead of 'mbr' disklabel

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -367,11 +367,11 @@ if [ -n "${FDISK_PARTITION_LAYOUT_INPUT}" ]; then
         FDISK_PARTITION_LAYOUT="${FDISK_PARTITION_LAYOUT_INPUT}"
 elif [ -z "${FDISK_PARTITION_LAYOUT}" ]; then
         FDISK_PARTITION_LAYOUT="${SBINDIR}/fdisk-4-partition-layout.txt"
-        # This fdisk-4-partition-layout.txt file only suitable to mbr partition type,
+        # This fdisk-4-partition-layout.txt file only suitable to mbr/dos partition type,
         # but not all fdisk versions support -t. So we test and assign if it is available
-        fdisk -t mbr |& grep -q \\-t
+        fdisk -t dos |& grep -q \\-t
         if [ $? -eq 0 ]; then
-	    PARTITIONTYPE="-t mbr"
+	    PARTITIONTYPE="-t dos"
         fi
 fi
 


### PR DESCRIPTION
The 'mbr' disklabel is an alias to 'dos' and is available on a smaller
subset of fdisk versions (introduced only since util-linux v2.26,
see commit 4a79a8f1 on
git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git)

Since specifying 'mbr' or 'dos' for the disklabel results in the same
thing and 'dos' is available in a greater number of fdisk versions, we
should prefer to use 'dos' over 'mbr'.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>