### PR TITLE
cubeit-installer: use 'dos' if 'mbr' disklabel type not available

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -363,16 +363,31 @@ LXCLABEL="OVERCCN"
 
 PARTITIONTYPE=""
 
+if test ! $(which fdisk); then
+	debugmsg ${DEBUG_CRIT} "[ERROR]: Unable to find 'fdisk'."
+	debugmsg ${DEBUG_CRIT} "[ERROR]: Please ensure fdisk is installed and in your PATH."
+	exit 1
+fi
+# Get supported fdisk command line options
+avail_fdisk_options=$(fdisk -h | grep "^\ *-" | cut -d',' -f1 | xargs)
+
+
 if [ -n "${FDISK_PARTITION_LAYOUT_INPUT}" ]; then
         FDISK_PARTITION_LAYOUT="${FDISK_PARTITION_LAYOUT_INPUT}"
 elif [ -z "${FDISK_PARTITION_LAYOUT}" ]; then
         FDISK_PARTITION_LAYOUT="${SBINDIR}/fdisk-4-partition-layout.txt"
         # This fdisk-4-partition-layout.txt file only suitable to mbr partition type,
         # but not all fdisk versions support -t. So we test and assign if it is available
-        fdisk -t mbr |& grep -q \\-t
-        if [ $? -eq 0 ]; then
-	    PARTITIONTYPE="-t mbr"
-        fi
+
+	# If fdisk supports the '-t' disklabel option use it. Determine which variant to
+	# use, prefer to use 'mbr' when available (though currently the same as 'dos')
+	if [[ $avail_fdisk_options == *"-t"* ]]; then
+		if $(fdisk -t mbr 2>&1 | grep -q unsupported); then
+			PARTITIONTYPE="-t dos"
+		else
+			PARTITIONTYPE="-t mbr"
+		fi
+	fi
 fi
 
 debugmsg ${DEBUG_INFO} "[INFO]: creating partitions using (${FDISK_PARTITION_LAYOUT})"


### PR DESCRIPTION
The 'mbr' disklabel type is an alias to the 'dos' disklable type and
was only introduced since util-linux v2.26 (see commit 4a79a8f1 on
git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git). This
means that the 'mbr' type is not available in all fdisk version that
support the '-t' disklabel option.

In order to allow the installer to work seamlessly with a broad range
of fdisk versions we use the output of fdisk help to tailor which
options we need to set and which values we pass for these options. We
add logic to easily query supported options and to fix installer
creation issues with versions of fdisk which don't understand the
'mbr' disklabel type, we pass 'dos' instead.

NOTE that at this time 'mbr' and 'dos' types are synonymous but this
change will make distinguishing between the two easy should this ever
change and the need ever arise to deal with the disklabel differently.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>