### PR TITLE
overc-install: config the network prime's lxc network

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -905,10 +905,10 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	if [ -e "${pathtocontainer}/config" ]; then
 	    # Pass the network device through to the designated network prime container
 	    if [ ! -z "${NETWORK_DEVICE_CLASSES}" ]; then
-		echo "overc.network.linkdevs = $NETWORK_DEVICE_CLASSES" >> ${pathtocontainer}/config
-	        # Set the network prime device classes
-	        sed -i "s/^\(network_prime_device_class:\).*$/\1 ${NETWORK_DEVICE_CLASSES}/" \
-		    ${TMPMNT}/etc/overc-conf/ansible/overc_config_vars.yml
+	    	for i in ${NETWORK_DEVICE_CLASSES}; do
+	    	     echo "lxc.network.type = phys" >> ${pathtocontainer}/config
+	             echo "lxc.network.link = $i" >> ${pathtocontainer}/config
+	        done
 	    fi
 
 	    # Enable configuring the network prime container by ansible on first boot


### PR DESCRIPTION
configure the network prime's lxc network useing
NETWORK_DEVICE_CLASSES.

If want to move a pattern of network interfaces
such as "ethXXX", "wlXXX" and so on to network
prime namespace, please add:

NETWORK_DEVICE_CLASSES = "eth+ wl+"

to your installer config file. The appendix of '+'
will trigger an string pattern matching process to
match all of the network interfaces prefixed with
'eth' and 'wl'.

Signed-off-by: fli <fupan.li@windriver.com>