### PR TITLE
cubeit-installer: rename the boot entry "Automatic Key Provision"

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -724,7 +724,7 @@ menuentry "$DISTRIBUTION recovery" {
        chainloader /bzImage_bakup root=LABEL=OVERCROOTFS rootflags=subvol=rootfs_bakup ro rootwait initrd=/initrd
 }
 
-menuentry 'Automatic Key Provision' {
+menuentry 'Automatic Certificate Provision' {
        chainloader /EFI/BOOT/LockDown.efi
 }
 EOF


### PR DESCRIPTION
Strictly speaking, it should be "Automatic Certificate Provision"
because the enrolled objects are the x509 certificates corresponding
to the private keys used to sign the image.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>