### PR TITLE
cubeit-installer: sanity check the private key

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -722,20 +722,28 @@ EOF
 	else
 	    cat <<EOF >mnt/EFI/BOOT/grub.cfg
 set default="0"
-set timeout=5
+set timeout=3
 set color_normal='light-gray/black'
 set color_highlight='light-green/blue'
 
+insmod efivar
+get_efivar -f uint8 -s SECURE_OFF SetupMode
+
+if [ "\${SECURE_OFF}" = "1" ]; then
+    set timeout=0
+
+    menuentry "Automatic Certificate Provision" {
+        chainloader \${prefix}/LockDown.efi
+    }
+fi
+
 menuentry "$DISTRIBUTION" {
-       chainloader /bzImage root=LABEL=OVERCROOTFS ro rootwait initrd=/initrd
+    set fallback="$DISTRIBUTION recovery"
+    chainloader /bzImage root=LABEL=OVERCROOTFS ro rootwait initrd=/initrd
 }
 
 menuentry "$DISTRIBUTION recovery" {
-       chainloader /bzImage_bakup root=LABEL=OVERCROOTFS rootflags=subvol=rootfs_bakup ro rootwait initrd=/initrd
-}
-
-menuentry 'Automatic Certificate Provision' {
-       chainloader /EFI/BOOT/LockDown.efi
+    chainloader /bzImage_bakup root=LABEL=OVERCROOTFS rootflags=subvol=rootfs_bakup ro rootwait initrd=/initrd
 }
 EOF
 	fi

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -521,6 +521,16 @@ fi
 debugmsg ${DEBUG_INFO} "[INFO]: installing rootfs ($rootfs)"
 tar --numeric-owner -xpf $rootfs
 
+# sanity check the private key is available for IMA signing
+if [ $do_ima_sign -eq 1 ]; then
+    if [ ! -f etc/keys/privkey_evm.pem ]; then
+        if [ -z "${IMA_PRIVKEY}" -o ! -f "${IMA_PRIVKEY}" ]; then
+            debugmsg ${DEBUG_WARN} "[WARNING]: IMA signined disabled."
+            do_ima_sign=0
+        fi
+    fi
+fi
+
 mount /dev/${fs_dev}1 mnt
 
 ## Process kernel into /boot


### PR DESCRIPTION
If the private key is unavailable, the IMA signing will be disabled with
a warning message.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>