### PR TITLE
Revert "cubeit-installer: support to deploy the bundled kernel image"

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -547,16 +547,10 @@ elif [ -e boot/uImage-* ]; then
 	cp boot/uImage-* mnt/uImage
 	#create a backup kernel for recovery boot
 	cp boot/uImage-* mnt/uImage_bakup
-else
-	if [ -e boot/bzImage-initramfs* ]; then
-	    cp boot/bzImage-initramfs-* mnt/bzImage-initramfs
-	    cp boot/bzImage-initramfs-* mnt/bzImage-initramfs_bakup
-	fi
-
-	if [ -e boot/bzImage ]; then
-	    cp boot/bzImage mnt/bzImage
-	    cp boot/bzImage mnt/bzImage_bakup
-	fi
+elif [ -e boot/bzImage-* ]; then
+	cp boot/bzImage-* mnt/bzImage
+	#create a backup kernel for recovery boot
+	cp boot/bzImage-* mnt/bzImage_bakup
 fi
  
 ## Process initrd into /boot


### PR DESCRIPTION
This reverts commit f2ae82d7038343755aa15e0f47a7a72f3c8015da.

This commit doesn't consider the case without uefi secure boot. In that case, there is no bzImage symbol link file.