### PR TITLE
Implement 'dir' install type (v2)

### DIFF
--- a/README.variables
+++ b/README.variables
@@ -30,3 +30,10 @@ NETWORK_DEVICE:       The network device to passthrough to the network
 
 GRUB_KERNEL_PARAMS:   Kernel parameters appended to the boot line used by the
                       installed or live images. (cubeit-installer, x86 only).
+
+LOCAL_POST_FUNCTION_DEFS: Local function definitions which will be
+			  sourced by the installer scripts. When
+			  creating an on target installer this script
+			  and any other files found in the same
+			  directory will be copied to the installer
+			  media.

--- a/installers/harddrive-installer.sh
+++ b/installers/harddrive-installer.sh
@@ -63,15 +63,24 @@ custom_install_rules()
 	## Copy kernel and files to filesystem
 	debugmsg ${DEBUG_INFO} "Copying kernel image"
 	install_kernel "${INSTALL_KERNEL}" "${mnt_boot}"
-	assert_return $?
+	if [ $? -ne 0 ]; then
+	    debugmsg ${DEBUG_CRIT} "Failed to copy kernel image"
+	    return 1
+	fi
 
 	debugmsg ${DEBUG_INFO} "Extracting root filesystem "
 	extract_tarball "${INSTALL_ROOTFS}" "${mnt_rootfs}"
-	assert_return $?
+	if [ $? -ne 0 ]; then
+	    debugmsg ${DEBUG_CRIT} "Failed to copy root filesystem"
+	    return 1
+	fi
 	
 	debugmsg ${DEBUG_INFO} "Extracting kernel modules "
 	extract_tarball "${INSTALL_MODULES}" "${mnt_rootfs}"
-	assert_return $?
+	if [ $? -ne 0 ]; then
+	    debugmsg ${DEBUG_CRIT} "Failed to copy kernel modules"
+	    return 1
+	fi
 
 	return 0
 }

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -500,6 +500,12 @@ copy_installer_data()
 		cat $TARGET_CONFIG_FILE |
 			sed "s|\${ARTIFACTS_DIR}|${INSTALLER_TARGET_IMAGES_DIR}/containers|g" > \
 			${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+
+		# copy all files, which might be used by target configuration
+		if [ -e "${LOCAL_POST_FUNCTION_DEFS}" ] ; then
+		    debugmsg ${DEBUG_INFO} "Copying files from $(dirname $LOCAL_POST_FUNCTION_DEFS)."
+		    cp $(dirname $LOCAL_POST_FUNCTION_DEFS)/* ${destdir}${INSTALLER_TARGET_CONFIG_DIR}
+		fi
 	    else
 		echo "HDINSTALL_CONTAINERS=\"\\" > ${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
 		for c in ${HDINSTALL_CONTAINERS}; do

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -407,12 +407,16 @@ custom_install_rules()
 	##       and align things like grub to that name.
 	debugmsg ${DEBUG_INFO} "Copying kernel image"
 	install_kernel "${INSTALL_KERNEL}" "${mnt_boot}" "${initramfs_source}" "`basename ${INSTALL_INITRAMFS}`"
-	assert_return $?
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
 
 	if [ -n "${INSTALL_ROOTFS}" ]; then
 	    debugmsg ${DEBUG_INFO} "Extracting root filesystem (${INSTALL_ROOTFS})"
 	    extract_tarball "${INSTALL_ROOTFS}" "${mnt_rootfs}"
-	    assert_return $?
+	    if [ $? -ne 0 ]; then
+		return 1
+	    fi
 	else
 	    debugmsg ${DEBUG_INFO} "No rootfs specified, not extracting"
 	fi
@@ -420,13 +424,17 @@ custom_install_rules()
 	if [ -n "${INSTALL_MODULES}" ]; then
 	    debugmsg ${DEBUG_INFO} "Extracting kernel modules "
 	    extract_tarball "${INSTALL_MODULES}" "${mnt_rootfs}"
-	    assert_return $?
+	    if [ $? -ne 0 ]; then
+		return 1
+	    fi
 	else
 	    debugmsg ${DEBUG_INFO} "No kernel modules specified, not extracting"
 	fi
 
 	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_LIB_DIR}
-	assert_return $?
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
 
 	cp -r ${LIBDIR}/* ${mnt_rootfs}${INSTALLER_TARGET_LIB_DIR}
 	if [ $? -ne 0 ]; then
@@ -435,7 +443,9 @@ custom_install_rules()
 	fi
 
 	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_SBIN_DIR}
-	assert_return $?
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
 
 	cp ${SBINDIR}/* ${mnt_rootfs}${INSTALLER_TARGET_SBIN_DIR}
 	if [ $? -ne 0 ]; then
@@ -468,10 +478,14 @@ IFS=$OLDIFS
 
 	## Copy files from local workspace to USB drive
 	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}
-	assert_return $?
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
 
 	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_IMAGES_DIR}
-	assert_return $?
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
 
 	## Copy the common files from ${INSTALLER_FILES_DIR} to ${INSTALLER_TARGET_FILES_DIR}
 	## Here only chvt.service, other files maybe added in the future

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -55,8 +55,8 @@ cat << EOF
      --artifacts: directory where the binary inputs for image generation are found.
 		  The configuration script indicates what specific images will be used
 
-  cubeit is capable of creating images, or installers + payloads, with the value of
-  <target> indicating which type of image to create.
+  cubeit is capable of creating images, or installers + payloads, or simply payloads
+  with the value of <target> indicating which type of image to create.
 
      <target>: The output of the script.
 
@@ -74,6 +74,13 @@ cat << EOF
 			      written or flashed to a device and directly booted .. or
                               directly booted via qemu.
 
+	  - <path_to_dir>: Generate an install media directory. This mode produces a
+			   directory with the installer and installer data required to
+			   complete an install. This is similar to the bootable USB
+			   installer without the bootable part, allowing the result to
+			   be copied to an existing bootable USB device or accessed via
+			   NFS to complete an install on a running system.
+
   examples:
 
       # network block device
@@ -87,6 +94,9 @@ cat << EOF
 
       # image
       $ cubeit --force --config config-live.sh --artifacts `pwd` /tmp/overc.img
+
+      # installer + installer data
+      $ cubeit --artifacts `pwd` /tmp/installer_dir
 
 EOF
 }
@@ -279,9 +289,9 @@ for d in ${CONFIG_DIRS} ${INSTALLER_FILES_DIR}; do
 	INSTALL_GRUBCFG=${d}/${INSTALL_GRUBUSBCFG}
     fi
 done
-if [ -z "${INSTALL_GRUBUSBCFG}" ]; then
-    echo "ERROR: usb grub configuration ${INSTALL_GRUBUSBCFG} not found"
-    exit 1
+if [ "$TARGET_TYPE" != "dir" ] && [ -z "${INSTALL_GRUBUSBCFG}" ]; then
+        echo "ERROR: usb grub configuration ${INSTALL_GRUBUSBCFG} not found"
+        exit 1
 fi
 
 # Locations on the USB bootable drive fr installer configuration
@@ -333,7 +343,19 @@ case $TARGET_TYPE in
 	fi
 	;;
     dir)
-	# TODO: not currently implemented
+	if [ -d "$target" ]; then
+		if [ -n "$(ls -A $target)" -a -z "$FORCE" ]; then
+			debugmsg ${DEBUG_CRIT} "Directory  ($target) already exists and it is not empty. Remove it and restart"
+			false
+			assert $?
+		fi
+		rm -r $target
+	else
+		debugmsg ${DEBUG_CRIT} "The destination is not a directory."
+		false
+		assert $?
+	fi
+	mkdir -p $target
 	;;
     image)
 	if [ -e $target ]; then
@@ -658,6 +680,37 @@ custom_install_rules()
 	return 0
 }
 
+# Install installer files into a destination directory
+# The installation can be gzipped and transfered to the target for deployment.
+# It is usefull in the context when board is booted over nfs or from other media.
+custom_install_rules_dir()
+{
+	local destdir="$1"
+
+	# copy installer 'static' content
+	copy_installer "${destdir}"
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
+
+	## And initramfs
+	cp "${INSTALL_INITRAMFS}" ${destdir}${INSTALLER_TARGET_IMAGES_DIR}
+	if [ $? -ne 0 ]; then
+	    debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy '${INSTALL_INITRAMFS}' to '${destdir}${INSTALLER_TARGET_IMAGES_DIR}'"
+	    return 1
+	fi
+
+	## ----------------------------------------------------------
+	## Things that will be installed to the hard drive below here
+	## ----------------------------------------------------------
+	copy_installer_data "${destdir}"
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
+
+	return 0
+}
+
 # In a desktop environment, disable the automounter to automatically
 # mount the inserted media and Nautilus automatically pops up a
 # window to open a folder during installing to avoid umount failures
@@ -716,7 +769,7 @@ case $TARGET_TYPE in
 	installer_main "$dev"
 	;;
     dir)
-	# TODO: not currently implemented
+	installer_dir "$target"
 	;;
     image)
 	export TARGET_TYPE=$TARGET_TYPE

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -376,6 +376,160 @@ install_summary()
 
 }
 
+#
+# Copy the installer 'static' parts, that is scripts, dirs,
+# files, libs...
+#
+# Configs are not static and so are dealt with as content
+# and copied later, see copy_installer_data().
+#
+copy_installer()
+{
+	local destdir="$1"
+
+	debugmsg ${DEBUG_INFO} "Copying installer to install media"
+	recursive_mkdir ${destdir}${INSTALLER_TARGET_LIB_DIR}
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
+
+	cp -r ${LIBDIR}/* ${destdir}${INSTALLER_TARGET_LIB_DIR}
+	if [ $? -ne 0 ]; then
+		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy lib files"
+		return 1
+	fi
+
+	recursive_mkdir ${destdir}${INSTALLER_TARGET_SBIN_DIR}
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
+
+	cp ${SBINDIR}/* ${destdir}${INSTALLER_TARGET_SBIN_DIR}
+	if [ $? -ne 0 ]; then
+		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy sbin files"
+		return 1
+	fi
+
+	# put the installers in with the sbin files
+	cp ${INSTALLERS_DIR}/* ${destdir}${INSTALLER_TARGET_SBIN_DIR}
+	if [ $? -ne 0 ]; then
+		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy installer files"
+		return 1
+	fi
+
+	# and any extended functions/callbacks
+	if [ -n "${FUNCTIONS_TO_COPY}" ]; then
+	    debugmsg ${DEBUG_INFO} "Copying target installer functions: ${FUNCTIONS_TO_COPY}"
+OLDIFS=$IFS
+IFS='
+'
+	    for f in ${FUNCTIONS_TO_COPY}; do
+		# remove any leading spaces
+		a=`echo $f | sed 's/^ *//g'`
+		if [ -e "${a}" ]; then
+		    cp -f "${a}" ${destdir}${INSTALLER_TARGET_SBIN_DIR}
+		fi
+	    done
+IFS=$OLDIFS
+	fi
+
+	## Copy files from local workspace to USB drive
+	recursive_mkdir ${destdir}${INSTALLER_TARGET_FILES_DIR}
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
+
+	## Copy the common files from ${INSTALLER_FILES_DIR} to ${INSTALLER_TARGET_FILES_DIR}
+	## Here only chvt.service, other files maybe added in the future
+	COMMON_FILES="chvt.service"
+	for f in ${COMMON_FILES}; do
+		if [ -e ${INSTALLER_FILES_DIR}/${f} ]; then
+			cp ${INSTALLER_FILES_DIR}/${f} ${destdir}${INSTALLER_TARGET_FILES_DIR}/
+		fi
+	done
+
+	recursive_mkdir ${destdir}${INSTALLER_TARGET_IMAGES_DIR}
+	if [ $? -ne 0 ]; then
+	    return 1
+	fi
+
+	return 0
+}
+
+#
+# Copies installer data (container images, dynamic configs...)
+#
+copy_installer_data()
+{
+	local destdir="$1"
+
+	debugmsg ${DEBUG_INFO} "Copying installer data to install media"
+	if [ -n "${HDINSTALL_ROOTFS}" ]; then
+	    ## Copy the Linux rootfs tarball(s) to USB drive
+            for i in ${HDINSTALL_ROOTFS}; do
+	        cp ${i} ${destdir}${INSTALLER_TARGET_IMAGES_DIR}
+	        if [ $? -ne 0 ]; then
+		    debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy hard drive install root filesystem"
+		    return 1
+	        fi
+            done
+	fi
+
+	# deal with any packages
+	if [ -n "${PACKAGES_DIR}" ]; then
+	    debugmsg ${DEBUG_INFO} "Copying RPMs to install media"
+	    recursive_mkdir ${destdir}/${INSTALLER_TARGET_IMAGES_DIR}/packages
+	    cp -r ${PACKAGES_DIR} ${destdir}/${INSTALLER_TARGET_IMAGES_DIR}/packages
+	fi
+
+	# containers
+	# make a container map, based on the HDINSTALL_CONTAINERS
+	if [ -n "${HDINSTALL_CONTAINERS}" ]; then
+	    debugmsg ${DEBUG_INFO} "Copying Containers to install media"
+
+	    recursive_mkdir ${destdir}${INSTALLER_TARGET_IMAGES_DIR}/containers
+	    recursive_mkdir ${destdir}${INSTALLER_TARGET_CONFIG_DIR}
+
+	    # drop any properties and copy the containers to the installer
+	    for c in `strip_properties ${HDINSTALL_CONTAINERS}`; do
+		cp ${c} ${destdir}/${INSTALLER_TARGET_IMAGES_DIR}/containers/
+	    done
+
+	    # create a configuration that can be read by the cubeit-installer
+	    if [ -v TARGET_CONFIG_FILE -a -n "$TARGET_CONFIG_FILE" ]; then
+		cat $TARGET_CONFIG_FILE |
+			sed "s|\${ARTIFACTS_DIR}|${INSTALLER_TARGET_IMAGES_DIR}/containers|g" > \
+			${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+	    else
+		echo "HDINSTALL_CONTAINERS=\"\\" > ${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+		for c in ${HDINSTALL_CONTAINERS}; do
+		    echo -n "${INSTALLER_TARGET_IMAGES_DIR}/containers/" >> ${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+		    echo -n `basename ${c}` >> ${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+		    echo " \\" >> ${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+		done
+		echo "\"" >> ${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+	    fi
+	    echo "DISTRIBUTION=\"$DISTRIBUTION\"" >>${destdir}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+	fi
+
+	if [ -n "${HD_MODULES}" ]; then
+	    ## Copy the kernel modules tarball to USB drive
+	    cp ${HD_MODULES} ${destdir}${INSTALLER_TARGET_FILES_DIR}
+	    if [ $? -ne 0 ]
+	    then
+		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy kernel modules"
+		return 1
+	    fi
+	fi
+
+	if [ -e "$INSTALL_SMARTCONFIG" ]; then
+		debugmsg ${DEBUG_INFO} "Install smart config $INSTALL_SMARTCONFIG"
+		cp $INSTALL_SMARTCONFIG ${destdir}/${INSTALLER_TARGET_IMAGES_DIR}/config.smart
+	fi
+
+	return 0
+}
+
 custom_install_rules()
 {
 	local mnt_boot="$1"
@@ -431,70 +585,11 @@ custom_install_rules()
 	    debugmsg ${DEBUG_INFO} "No kernel modules specified, not extracting"
 	fi
 
-	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_LIB_DIR}
+	# copy installer 'static' content
+	copy_installer "${mnt_rootfs}"
 	if [ $? -ne 0 ]; then
 	    return 1
 	fi
-
-	cp -r ${LIBDIR}/* ${mnt_rootfs}${INSTALLER_TARGET_LIB_DIR}
-	if [ $? -ne 0 ]; then
-		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy lib files"
-		return 1
-	fi
-
-	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_SBIN_DIR}
-	if [ $? -ne 0 ]; then
-	    return 1
-	fi
-
-	cp ${SBINDIR}/* ${mnt_rootfs}${INSTALLER_TARGET_SBIN_DIR}
-	if [ $? -ne 0 ]; then
-		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy sbin files"
-		return 1
-	fi
-
-	# put the installers in with the sbin files
-	cp ${INSTALLERS_DIR}/* ${mnt_rootfs}${INSTALLER_TARGET_SBIN_DIR}
-	if [ $? -ne 0 ]; then
-		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy installer files"
-		return 1
-	fi
-
-	# and any extended functions/callbacks
-	if [ -n "${FUNCTIONS_TO_COPY}" ]; then
-	    debugmsg ${DEBUG_INFO} "Copying target installer functions: ${FUNCTIONS_TO_COPY}"
-OLDIFS=$IFS
-IFS='
-'
-	    for f in ${FUNCTIONS_TO_COPY}; do
-		# remove any leading spaces
-		a=`echo $f | sed 's/^ *//g'`
-		if [ -e "${a}" ]; then
-		    cp -f "${a}" ${mnt_rootfs}${INSTALLER_TARGET_SBIN_DIR}
-		fi
-	    done
-IFS=$OLDIFS
-	fi
-
-	## Copy files from local workspace to USB drive
-	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}
-	if [ $? -ne 0 ]; then
-	    return 1
-	fi
-
-	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_IMAGES_DIR}
-	if [ $? -ne 0 ]; then
-	    return 1
-	fi
-
-	## Copy the common files from ${INSTALLER_FILES_DIR} to ${INSTALLER_TARGET_FILES_DIR}
-	## Here only chvt.service, other files maybe added in the future
-	COMMON_FILES="chvt.service" 
-	for f in ${COMMON_FILES}; do
-		if [ -e ${INSTALLER_FILES_DIR}/${f} ]; then
-			cp ${INSTALLER_FILES_DIR}/${f} ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/
-		fi
-	done
 
 	if ${X86_ARCH}; then
 		## Copy the hard drive GRUB configuration
@@ -549,69 +644,11 @@ IFS=$OLDIFS
 	## ----------------------------------------------------------
 	## Things that will be installed to the hard drive below here
 	## ----------------------------------------------------------
-	if [ -n "${HDINSTALL_ROOTFS}" ]; then
-	    ## Copy the Linux rootfs tarball(s) to USB drive
-            for i in ${HDINSTALL_ROOTFS}; do               
-	        cp ${i} ${mnt_rootfs}${INSTALLER_TARGET_IMAGES_DIR}
-	        if [ $? -ne 0 ]; then
-		    debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy hard drive install root filesystem"
-		    return 1
-	        fi
-            done
+	copy_installer_data "${mnt_rootfs}"
+	if [ $? -ne 0 ]; then
+	    return 1
 	fi
 
-	# deal with any packages
-	if [ -n "${PACKAGES_DIR}" ]; then
-	    debugmsg ${DEBUG_INFO} "Copying RPMs to install media"
-	    recursive_mkdir ${mnt_rootfs}/${INSTALLER_TARGET_IMAGES_DIR}/packages
-	    cp -r ${PACKAGES_DIR} ${mnt_rootfs}/${INSTALLER_TARGET_IMAGES_DIR}/packages
-	fi
-
-	# containers
-	# make a container map, based on the HDINSTALL_CONTAINERS
-	if [ -n "${HDINSTALL_CONTAINERS}" ]; then
-	    debugmsg ${DEBUG_INFO} "Copying Containers to install media"
-
-	    recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_IMAGES_DIR}/containers
-	    recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}
-
-	    # drop any properties and copy the containers to the installer
-	    for c in `strip_properties ${HDINSTALL_CONTAINERS}`; do
-		cp ${c} ${mnt_rootfs}/${INSTALLER_TARGET_IMAGES_DIR}/containers/
-	    done
-
-	    # create a configuration that can be read by the cubeit-installer
-	    if [ -v TARGET_CONFIG_FILE -a -n "$TARGET_CONFIG_FILE" ]; then
-		cat $TARGET_CONFIG_FILE |
-			sed "s|\${ARTIFACTS_DIR}|${INSTALLER_TARGET_IMAGES_DIR}/containers|g" > \
-			${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
-	    else
-		echo "HDINSTALL_CONTAINERS=\"\\" > ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
-		for c in ${HDINSTALL_CONTAINERS}; do
-		    echo -n "${INSTALLER_TARGET_IMAGES_DIR}/containers/" >> ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
-		    echo -n `basename ${c}` >> ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
-		    echo " \\" >> ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
-		done
-		echo "\"" >> ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
-	    fi
-	    echo "DISTRIBUTION=\"$DISTRIBUTION\"" >>${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
-	fi
-
-	if [ -n "${HD_MODULES}" ]; then
-	    ## Copy the kernel modules tarball to USB drive
-	    cp ${HD_MODULES} ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}
-	    if [ $? -ne 0 ]
-	    then
-		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy kernel modules"
-		return 1
-	    fi
-	fi
-
-	if [ -e "$INSTALL_SMARTCONFIG" ]; then
-		debugmsg ${DEBUG_INFO} "Install smart config $INSTALL_SMARTCONFIG"
-		cp $INSTALL_SMARTCONFIG ${mnt_rootfs}/${INSTALLER_TARGET_IMAGES_DIR}/config.smart
-	fi
-	
 	return 0
 }
 

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -65,14 +65,6 @@ assert()
 	fi
 }
 
-assert_return()
-{
-	if [ $1 -ne 0 ]
-	then
-		return $1
-	fi
-}
-
 trap_handler()
 {
 	case $1 in

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -1097,3 +1097,46 @@ format_menuitems()
 	done
 	return $itemcount
 }
+
+installer_dir()
+{
+	local destdir="$1"
+
+	if [ -z $destdir ]
+	then
+		debugmsg ${DEBUG_CRIT} "ERROR: Could not determine destination directory"
+	fi
+
+	## Display installer banner
+	display_banner
+
+	## Verify that installation files exist
+	verify_prerequisite_files
+	assert $?
+
+	declare -f install_summary > /dev/null 2>&1
+	if [ $? -eq 0 ]
+	then
+		install_summary
+	fi
+
+	## Display Installer Introduction
+	display_introduction
+	assert $?
+
+	declare -f custom_install_rules_dir > /dev/null 2>&1
+	if [ $? -ne 0 ]
+	then
+		debugmsg ${DEBUG_CRIT} "ERROR: Could not determine how to install files"
+		false
+		assert $?
+	else
+		custom_install_rules_dir "${destdir}"
+		assert $?
+	fi
+
+	clean_up
+
+	# Finish Installation
+	display_finalmsg
+}


### PR DESCRIPTION
Changes since V1:

* The biggest issue with v1 was around the format used to check return codes. I have changed these to the format requested in v1.

* I dropped the assert_return() function which is no longer used

* Added a error message to the exit code checking on the 'cp' command found in the new custom_install_rules_dir(). Since we have many calls to 'cp' we should possibly create a wrapper around it where we could do preliminary checks like src/dst checks readable/writeable... and possibly even capture stderr around 'cp' to be able to provide comprehensive error reporting, but that is beyond the scope of these changes.
