### PR TITLE
cubeit: Allow install media to be created with a virtual device

### DIFF
--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -277,6 +277,7 @@ validate_usbstorage()
 	echo $parent | grep -q virtual
 	if [ $? -eq 0 ]; then
 	    # this is a virtual block device, return ok
+	    echo $(basename ${usbstorage_device})
 	    return 0
 	fi
 


### PR DESCRIPTION
There is was a minor bug in cubeit where it did not provide the device
name of the virtual device in order for the script to continue using
the device name.  Instead it would fail stating the device could not
be found.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>