### PR TITLE
cubeit-installer: fix labelling btrfs subvolume

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -326,13 +326,13 @@ ima_sign()
 
     for dir in `ls $root_dir`; do
         local dst_dir="$root_dir/$dir"
+	local skip_signing=0
 
         for _dir in $mnt_dirs; do
             # skip root directory
             [ "$_dir" = "$root_dir" ] && continue
 
             local fs_type="`grep $_dir /proc/mounts | awk '{ print $3 }'`"
-            local skip_signing=0
 
             if [ "$dst_dir" = "$_dir" ]; then
                 if [ $fs_type != "btrfs" -a $fs_type != "ext4" ]; then
@@ -1139,10 +1139,14 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
     [ $do_ima_sign -eq 1 ] &&
         ima_sign "${TMPMNT}/var/lib/lxc"
 
+    sync
+    umount ${TMPMNT}/var/lib/lxc
+
     if [ $btrfs -eq 1 ]; then
         if [ -z "$subvol" ]; then
             debugmsg ${DEBUG_WARN} "[WARNING]: Could not get subvolume id, thus cannot create factory reset snapshot"
         else
+            mount /dev/${lxc_fs_dev} ${TMPMNT}/var/lib/lxc
             btrfs subvolume set-default $subvol ${TMPMNT}/var/lib/lxc
             btrfs subvolume snapshot ${TMPMNT}/var/lib/lxc/workdir ${TMPMNT}/var/lib/lxc/${FACTORY_SNAPSHOT}
             #snapshot subvolume recursively
@@ -1154,10 +1158,10 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
                     btrfs subvolume snapshot "${TMPMNT}/var/lib/lxc/workdir/${subvolume}" "${TMPMNT}/var/lib/lxc/${FACTORY_SNAPSHOT}/$(dirname ${subvolume})"
                 fi
             done
+            sync
+            umount ${TMPMNT}/var/lib/lxc
         fi
     fi
-
-    umount "${TMPMNT}/var/lib/lxc"
 fi
 
 if [ -d "${PACKAGESDIR}" ]; then


### PR DESCRIPTION
The commit 41b020c8 introduces a regression which causes the subvolume cannot
be labbeled correctly.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>