### PR TITLE
overc-installer:Enable support for FIT image of kernel

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -559,6 +559,10 @@ elif [ -e boot/bzImage-* ]; then
 	cp boot/bzImage-* mnt/bzImage
 	#create a backup kernel for recovery boot
 	cp boot/bzImage-* mnt/bzImage_bakup
+elif [ -e boot/fitImage-* ]; then
+	cp boot/fitImage-* mnt/fitImage
+	#create a backup kernel for recovery boot
+	cp boot/fitImage-* mnt/fitImage_bakup
 fi
  
 ## Process initrd into /boot


### PR DESCRIPTION
Uboot support FIT image for kernel & dtb, enable support in overc-installer.

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>