### PR TITLE
cubeit-installer: mute the evict failure message

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -480,7 +480,7 @@ lxc_fs_dev=${fs_dev}4
 
 if [ $do_encryption -eq 1 ]; then
     ## Evict all objects for the first creation.
-    luks-setup.sh -f -e -d /dev/${rootfs_dev} -n "${ROOTLABEL}_encrypted"
+    luks-setup.sh -f -e -d /dev/${rootfs_dev} -n "${ROOTLABEL}_encrypted" >/dev/null 2>&1
     rootfs_dev="mapper/${ROOTLABEL}_encrypted"
 fi
 


### PR DESCRIPTION
If tpm is not initialized ever, the evict operation will always fail. In this
case, the error messages should not be printed.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>