### PR TITLE
cubeit: Allow for copying extra artifacts to the images directory

### DIFF
--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -517,6 +517,15 @@ copy_installer_data()
 		cp ${c} ${destdir}/${INSTALLER_TARGET_IMAGES_DIR}/containers/
 	    done
 
+	    # Copy additional artifacts
+	    if [ "${EXTRA_ARTIFACTS}" != "" ] ; then
+		(
+		    debugmsg ${DEBUG_INFO} "Copying Extra Artifacts to install media"
+		    cd ${ARTIFACTS_DIR}
+		    cp ${EXTRA_ARTIFACTS} ${destdir}/${INSTALLER_TARGET_IMAGES_DIR}
+		)
+	    fi
+
 	    # create a configuration that can be read by the cubeit-installer
 	    if [ -v TARGET_CONFIG_FILE -a -n "$TARGET_CONFIG_FILE" ]; then
 		cat $TARGET_CONFIG_FILE |


### PR DESCRIPTION
When using the cubeit with the "directory" mode for creating offline
install directories sometimes it is necessary to copy in additional
artifacts.  The additional artifacts are used to customize the image
via a location function which cube it already calls from the install
template.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>