### PR TITLE
overc-cctl,cubeit-installer: Remove securityfs from fstab

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -887,6 +887,8 @@ sed -i '/^proc/d' ${TMPMNT}/etc/fstab
 sed -i '/^devpts/d' ${TMPMNT}/etc/fstab
 sed -i '/^tmpfs/d' ${TMPMNT}/etc/fstab
 sed -i '/^usbdevfs/d' ${TMPMNT}/etc/fstab
+# If using IMA it should /sys/kernel/security is mounted by the container manager
+sed -i '/^securityfs/d' ${TMPMNT}/etc/fstab
 
 if [ "$SWAPLABEL" != "NOSWAP" ] ; then
 	echo "LABEL=$SWAPLABEL none swap sw 0 0" >> ${TMPMNT}/etc/fstab

--- a/sbin/overc-cctl
+++ b/sbin/overc-cctl
@@ -480,6 +480,7 @@ function deploy_new_container {
 		sed -i '/^devpts/d' ${pathtocontainer}/rootfs/etc/fstab
 		sed -i '/^tmpfs/d' ${pathtocontainer}/rootfs/etc/fstab
 		sed -i '/^usbdevfs/d' ${pathtocontainer}/rootfs/etc/fstab
+		sed -i '/^securityfs/d' ${pathtocontainer}/rootfs/etc/fstab
 	fi
 	#Since lxc.network.name set the veth's name as veth0, thus we should 
 	#Set the match name in 20-wired.network according to veth*.


### PR DESCRIPTION
In the case of running IMA in a container the securitfs will be added
to the container pre-mount setup.  If it is in the fstab generically
without IMA the systemd remount service will fail because securityfs
is not actually mounted.  There is also no point in remounting the
securityfs during the container start in general.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>