### PR TITLE
overc-cctl: Do not wait around to kill the container

### DIFF
--- a/sbin/overc-cctl
+++ b/sbin/overc-cctl
@@ -825,7 +825,7 @@ function switch_container {
 
 function stop_container {
 	echo -n "Stopping container ${cn} .... "
-	lxc-stop -n ${cn}
+	lxc-stop -n ${cn} -k
 	echo "done"
 }
 


### PR DESCRIPTION
When it is time to stop die quickly with the -k option.
   lxc-stop -n CONTAINER -k

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>