### PR TITLE
cubeit-installer: Call partx -a -v to avoid partition mapping failure

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -490,6 +490,7 @@ if [ $(echo $raw_dev | grep -c 'loop') ==  "1" ]; then
        loop_device=t
        fs_dev="${raw_dev}p"
        partprobe /dev/${raw_dev}
+       which partx && partx -a -v /dev/${raw_dev}
 fi
 
 if [ "$SWAPLABEL" != "NOSWAP" ] ; then


### PR DESCRIPTION
If partx was previously used on one of the loop devices for some other
project or reason the partprobe does not always map the partition and
upate the kernel partition table.

If the partx binary is availble call it so that the partition table
will get update properly regardless of who used it last.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>