### PR TITLE
cubeit-installer: fix tar options

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -576,7 +576,7 @@ fi
 # we are either in ${TMPMNT} or ${TMPMNT}/rootfs
 debugmsg ${DEBUG_INFO} "[INFO]: installing rootfs ($rootfs)"
 tar --warning=no-timestamp --numeric-owner \
-    --xattrs --xattrs-include=security\\.ima-xpf "${rootfs}"
+    --xattrs --xattrs-include=security\\.ima -xpf "${rootfs}"
 
 # sanity check whether the private key is available for IMA signing
 if [ $do_ima_sign -eq 1 ]; then


### PR DESCRIPTION
The commit 496997cb has a typo with -xpf options, causing the live image
cannot be signed with IMA signatures.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>