### PR TITLE
overc-installer: only create the grub.cfg file when no one in boot/ef…

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -622,7 +622,7 @@ EOF
 
 	if [ -n "${INSTALL_GRUBEFI_CFG}" -a -f "${INSTALL_GRUBEFI_CFG}" ]; then
 	    cp "${INSTALL_GRUBEFI_CFG}" mnt/EFI/BOOT/grub.cfg
-	else
+	elif [ ! -f mnt/EFI/BOOT/grub.cfg ]; then
 	    cat <<EOF >mnt/EFI/BOOT/grub.cfg
 set default="0"
 set timeout=5


### PR DESCRIPTION
…i/EFI/BOOT dir

The priority of the grub.cfg file is $INSTALL_GRUBEFI_CFG (specified in installer config)
>  grub-efi installed into boot/efi/EFI/BOOT dir > created in cubeit-installer script.

Signed-off-by: Fupan Li <fupan.li@windriver.com>