### PR TITLE
cubeit-installer: Add another call to partx

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -422,6 +422,8 @@ if [ $(echo $raw_dev | grep -c 'loop') ==  "1" ]; then
        loop_device=t
        fs_dev="${raw_dev}p"
        partprobe /dev/${raw_dev}
+       # If partx is available resync all the partitions
+       which partx && partx -d /dev/${raw_dev}
        which partx && partx -a -v /dev/${raw_dev}
 fi
 


### PR DESCRIPTION
A corner case was found where the partition table of a loop device
existed but was stale with respect to /sys and udev.  In this case the
kernel partition map must be dropped with the partx -d before trying
to perform an add, else the add will fail with an error that the
partition mapping already exists when in fact it is wrong.

Testing of all the known corner cases and default operation where the
loop device is first initialized show that it is safe to always drop
the partition map before performing the add with partx.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>