### PR TITLE
cubeit-installer: Allow NETWORK_DEVICE to use 1 or more device and wi…

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -999,9 +999,6 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	if [ ! -v NETWORK_DEVICE ]; then
 	    NETWORK_DEVICE=""
 	fi
-	if [ ! -v NETWORK_DEVICE_CLASSES ]; then
-	    NETWORK_DEVICE_CLASSES=""
-	fi
 
 	pathtocontainer=${TMPMNT}/opt/container/${network_prime}
 	if [ -e "${pathtocontainer}/config.json" ]; then
@@ -1015,7 +1012,9 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 		    # need to pass through the physical device
 		    ${SBINDIR}/cube-cfg set cube.network.type:static
 		    ${SBINDIR}/cube-cfg --prepend set cube.network.ip:192.168.42.1/24
-		    ${SBINDIR}/cube-cfg device network:${NETWORK_DEVICE}:${NETWORK_DEVICE}
+		    for n in ${NETWORK_DEVICE}; do
+			${SBINDIR}/cube-cfg device network:${n}:${n}
+		    done
 		    ${SBINDIR}/cube-cfg attribute +netprime
 
 		    # ensure that etcd (on dom0) is accessible


### PR DESCRIPTION
…ld cards

The pflask updates allow the specification of an interface wild card
so as to take over one or more interfaces from the root namespace.
Example:

NETWORK_INTERFACE="en+ wl+"

This would cause any wlan0, wlan1, wlanX interface or enp0s3,
enp0s4... to be given to a pflask enabled container.

This patch also removes the NETWORK_DEVICE_CLASSES variable which is
no longer used.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>