### PR TITLE
IMA: retrieve IMA key's abs path

### DIFF
--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -257,8 +257,21 @@ fi
 
 ima_sign()
 {
+
+    # evmctl has problem with parsing a relative path of IMA key
+    # when recusively signing files under a directory
+    # so we convert KEYS_DIR into abs path
+    local realpath_bin=$(which realpath)
+    if [ -z "${realpath_bin}" ]; then
+	debugmsg ${DEBUG_CRIT} "[ERROR]: Unable to find 'realpath'."
+	debugmsg ${DEBUG_CRIT} "[ERROR]: Please ensure 'realpath' is installed and in your PATH."
+	exit 1
+    fi
+
+    KEYS_DIR_ABS="$(realpath ${KEYS_DIR})"
+
     evmctl ima_sign --hashalgo sha256 \
-        --key "${KEYS_DIR}/ima_keys/x509_ima.key" \
+        --key "${KEYS_DIR_ABS}/ima_keys/x509_ima.key" \
         --pass="${IMA_KEY_PASS}" \
         -r -t f "$1" &
 


### PR DESCRIPTION
If we pass a relative path to "--artifacts", IMA signing will report
the following error:

    Unable to open keyfile artifacts/user-keys/ima_keys/x509_ima.key

This is because 'evmctl' has some problem with parsing a relative path
for IMA key, so we convert the key's path to an absolute path.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>