### PR TITLE
grub2: Add fixes for host contamination

### DIFF
--- a/lib/prompts/0003_partition_config.sh
+++ b/lib/prompts/0003_partition_config.sh
@@ -115,7 +115,7 @@ partition_config()
 		fi
 	fi
 	if [ "$INSTALL_TYPE" == "installer" ]; then
-		echo "BOOTPART_START=\"63s\"" >> ${tmpconf}
+		echo "BOOTPART_START=\"2048s\"" >> ${tmpconf}
 		echo "BOOTPART_END=\"${bootpartsize}\"" >> ${tmpconf}
 		echo "BOOTPART_FSTYPE=\"fat32\"" >> ${tmpconf}
 		echo "BOOTPART_LABEL=\"OVERCBOOT\"" >> ${tmpconf}

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -449,6 +449,7 @@ if [ -z "${INSTALLER_TARGET_DIR}" ]; then
     INSTALLER_TARGET_DIR="/opt/installer"
 fi
 INSTALLER_TARGET_SBIN_DIR="${INSTALLER_TARGET_DIR}/sbin"
+INSTALLER_TARGET_INSTALLERS_DIR="${INSTALLER_TARGET_DIR}/installers"
 INSTALLER_TARGET_LIB_DIR="${INSTALLER_TARGET_DIR}/lib"
 INSTALLER_TARGET_CONFIG_DIR="${INSTALLER_TARGET_DIR}/config"
 INSTALLER_TARGET_FILES_DIR="${INSTALLER_TARGET_DIR}/files"
@@ -603,8 +604,10 @@ custom_install_rules()
 		return 1
 	fi
 
-	# put the installers in with the sbin files
-	cp ${INSTALLERS_DIR}/* ${mnt_rootfs}${INSTALLER_TARGET_SBIN_DIR}
+	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_INSTALLERS_DIR}
+	assert_return $?
+
+	cp ${INSTALLERS_DIR}/* ${mnt_rootfs}${INSTALLER_TARGET_INSTALLERS_DIR}
 	if [ $? -ne 0 ]; then
 		debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy installer files"
 		return 1
@@ -645,11 +648,22 @@ IFS=$OLDIFS
 	if ${X86_ARCH}; then
 		## Copy the hard drive GRUB configuration
 		for d in ${CONFIG_DIRS} ${INSTALLER_FILES_DIR}; do
+			if [ -e ${d}/${INSTALL_GRUBUSBCFG} ] &&
+			[ ! -e ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/${INSTALL_GRUBUSBCFG} ]; then
+				debugmsg ${DEBUG_CRIT} "INFO: found grub hd configuration ${d}/${INSTALL_GRUBUSBCFG}"
+				cp ${d}/${INSTALL_GRUBUSBCFG} ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/${INSTALL_GRUBUSBCFG}
+			fi
+
+			if [ -e "${d}/${INSTALL_GRUBUSBCFG}.p7b" ] &&
+			[ ! -e "${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/${INSTALL_GRUBUSBCFG}.p7b" ]; then
+				cp -f "${d}/${INSTALL_GRUBUSBCFG}.p7b" "${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}"
+			fi
+
 			if [ -e ${d}/${INSTALL_GRUBHDCFG} ] &&
 			[ ! -e ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/${INSTALL_GRUBHDCFG} ]; then
 				debugmsg ${DEBUG_CRIT} "INFO: found grub hd configuration ${d}/${INSTALL_GRUBHDCFG}"
 				cp ${d}/${INSTALL_GRUBHDCFG} ${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/${INSTALL_GRUBHDCFG}
-	    		fi
+			fi
 
 			if [ -e "${d}/${INSTALL_GRUBHDCFG}.p7b" ] &&
 			[ ! -e "${mnt_rootfs}${INSTALLER_TARGET_FILES_DIR}/${INSTALL_GRUBHDCFG}.p7b" ]; then
@@ -736,7 +750,7 @@ IFS=$OLDIFS
 	if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	    debugmsg ${DEBUG_INFO} "Copying Containers to install media"
 
-	    recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_IMAGES_DIR}/containers
+	    recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_IMAGES_DIR}
 	    recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}
 
 	    # drop any properties and copy the containers to the installer
@@ -750,18 +764,21 @@ IFS=$OLDIFS
 				return 1
 			fi
 		fi
-		cp ${img} ${mnt_rootfs}/${INSTALLER_TARGET_IMAGES_DIR}/containers/
+		cp ${img} ${mnt_rootfs}/${INSTALLER_TARGET_IMAGES_DIR}
 	    done
 
 	    # create a configuration that can be read by the cubeit-installer
 	    if [ -v TARGET_CONFIG_FILE -a -n "$TARGET_CONFIG_FILE" ]; then
-		cat $TARGET_CONFIG_FILE |
-			sed "s|\${ARTIFACTS_DIR}|${INSTALLER_TARGET_IMAGES_DIR}/containers|g" > \
-			${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+		cp $TARGET_CONFIG_FILE ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+		NEED_CONFIG_USB=$(grep "source config-usb.sh" ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh)
+		if [ -v NEED_CONFIG_USB -a -n "$NEED_CONFIG_USB" ]; then
+			cp $(dirname $TARGET_CONFIG_FILE)/config-usb.sh \
+				${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-usb.sh
+		fi
 	    else
 		echo "HDINSTALL_CONTAINERS=\"\\" > ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
 		for c in ${HDINSTALL_CONTAINERS}; do
-		    echo -n "${INSTALLER_TARGET_IMAGES_DIR}/containers/" >> ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
+		    echo -n "${INSTALLER_TARGET_IMAGES_DIR}/" >> ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
 		    echo -n `basename ${c}` >> ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
 		    echo " \\" >> ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}/config-installer.sh
 		done

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -844,7 +844,32 @@ disable_automounter
 
 case $TARGET_TYPE in
     block)
-	installer_main "$dev"
+	if [ -z "${TARGET_CONFIG_FILE}" ]; then
+	    if [ -n "${CONFIG_FILES}" ]; then
+		TARGET_CONFIG_FILE="${CONFIG_FILES}"
+	    else
+		TARGET_CONFIG_FILE="config-live.sh"
+	    fi
+	fi
+
+	device=$target
+	if [ -n "$INSTALLER_IMAGE" ]; then
+		dev=`basename $device`
+		installer_main "$dev"
+	else
+
+		if [ -n "${FDISK_PARTITION_LAYOUT_INPUT}" ];then
+		    debugmsg ${DEBUG_INFO} $INSTALLERS_DIR/cubeit-installer -b --artifacts ${ARTIFACTS_DIR} \
+			    --config ${TARGET_CONFIG_FILE} --partition_layout ${FDISK_PARTITION_LAYOUT_INPUT} ${INSTALL_ROOTFS} $device
+		    $INSTALLERS_DIR/cubeit-installer -b --artifacts ${ARTIFACTS_DIR} \
+			    --config ${TARGET_CONFIG_FILE} --partition_layout ${FDISK_PARTITION_LAYOUT_INPUT} ${INSTALL_ROOTFS} $device
+		else
+		    debugmsg ${DEBUG_INFO} $INSTALLERS_DIR/cubeit-installer -b --artifacts ${ARTIFACTS_DIR} \
+			    --config ${TARGET_CONFIG_FILE} ${INSTALL_ROOTFS} $device
+		    $INSTALLERS_DIR/cubeit-installer -b --artifacts ${ARTIFACTS_DIR} \
+			    --config ${TARGET_CONFIG_FILE} ${INSTALL_ROOTFS} $device
+		fi
+	fi
 	;;
     dir)
 	# TODO: not currently implemented

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -801,6 +801,7 @@ HAVE_DCONF=1
 DESKTOP_SESSION=""
 verify_utility gsettings && HAVE_GSETTING=0
 verify_utility dconf && HAVE_DCONF=0
+verify_commands
 
 ps -ef|grep gnome-session|grep -v grep >/dev/null 2>&1
 [ $? -eq 0 ] && DESKTOP_SESSION="gnome"

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -604,9 +604,9 @@ install_grub()
 	if [ ${GRUB_VER} == "0" ] && ( [[ ${device} = *nbd* ]] || [[ ${device} = *loop* ]] ); then
 	    mkdir -p ${mountpoint}/boot/grub
 	    echo "(hd0) /dev/${device}" > ${mountpoint}/boot/grub/device.map
-	    ${CMD_GRUB_INSTALL} --root-directory=${mountpoint} --no-floppy hd0 # > /dev/null 2>&1
+	    ${CMD_GRUB_INSTALL} --target=i386-pc --root-directory=${mountpoint} --no-floppy --modules=" boot linux ext2 fat serial part_msdos part_gpt normal iso9660 search" hd0 # > /dev/null 2>&1
 	else
-	    ${CMD_GRUB_INSTALL} --root-directory=${mountpoint} --no-floppy --recheck /dev/${device} # > /dev/null 2>&1
+	    ${CMD_GRUB_INSTALL} --target=i386-pc --root-directory=${mountpoint} --no-floppy --recheck --modules=" boot linux ext2 fat serial part_msdos part_gpt normal iso9660 search" /dev/${device} # > /dev/null 2>&1
 	    # Fedora 24 employs grub2-install which installs the files to DIR/grub2
 	    if [ -d "${mountpoint}/boot/grub2" ]; then
 		if ! mv "${mountpoint}/boot/grub2" "${mountpoint}/boot/grub"; then

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -309,6 +309,9 @@ validate_usbstorage()
         if [ "x${driver}" == "xusb-storage" ]; then
                 rc=0
 		echo $(basename ${usbstorage_device})
+        elif [ "x${driver}" == "xvirtio_blk" ]; then
+                rc=0
+		echo $(basename ${usbstorage_device})
         else
                 debugmsg ${DEBUG_CRIT} "ERROR: Specified block device (${usbstorage_device}) is not a usb-storage device."
                 rc=1


### PR DESCRIPTION
Move the starting point of the first partition from sector 63 to
sector 2048 to give it more time to store GRUB2 modules.

Force the target to use i386-pc to ensure that a MBR bootstrap
is included when building the image on x86_64-efi hosts.

Signed-off-by: Rob Woolley <rob.woolley@windriver.com>