### PR TITLE
Grub fixes

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -1096,8 +1096,11 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	debugmsg ${DEBUG_INFO} "[INFO]: Set initial user."
 	sed -i "s/^\(initial_user:\).*$/\1 ${INITIAL_USER}/" \
 	    ${TMPMNT}/etc/overc-conf/ansible/overc_config_vars.yml
-	echo "initial_passwd: `cat $CONFIG_FILES | grep INITIAL_PASSWD | cut -f 2 -d=`" \
-	    >> ${TMPMNT}/etc/overc-conf/ansible/overc_config_vars.yml
+            if [ ! -z "${INITIAL_PASSWD}" ]; then
+	        debugmsg ${DEBUG_INFO} "[INFO]: Set initial password."
+	        echo "initial_passwd: ${INITIAL_PASSWD}" \
+	            >> ${TMPMNT}/etc/overc-conf/ansible/overc_config_vars.yml
+            fi
     fi
 
     if [ -n "${LOCAL_CUSTOM_HDD_POST_FUNCS}" ]; then

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -605,7 +605,7 @@ if ${X86_ARCH}; then
     chroot ${TMPMNT} /bin/bash -c "mount -t sysfs sys /sys"
 
     if [ -n "$loop_device" ]; then
-	chroot ${TMPMNT} /bin/bash -c "grub-install --target=i386-pc --force --boot-directory=/mnt --modules=\" boot linux ext2 fat serial part_msdos part_gpt normal iso9660 search\" /dev/${raw_dev}"
+	chroot ${TMPMNT} /bin/bash -c "grub-install --target=i386-pc --force --boot-directory=/mnt --modules=\" boot linux ext2 fat serial part_msdos part_gpt normal iso9660 search chain\" /dev/${raw_dev}"
     else
 	chroot ${TMPMNT} /bin/bash -c "grub-install --target=i386-pc --boot-directory=/mnt --force /dev/${raw_dev}"
     fi

--- a/sbin/cubename
+++ b/sbin/cubename
@@ -58,7 +58,7 @@ function extract_container_name
     # [<prefix>]<type>-<name>-<rest>
     #
     # <prefix>: optional filename prefix
-    # <type>: cube, docker, lxc
+    # <type>: cube, docker, lxc, oci
     # <name>: dom or <string>
     # 
     # if name is 'dom', the next character or -<string> is the
@@ -100,6 +100,20 @@ function extract_container_name
     # <prefix>container-<name>-<rest>
     if [ "$type" = "container" ]; then
 	output=$type-$name
+    fi
+
+    # Other valid types
+    if [ "$type" = "docker" ] || \
+       [ "$type" = "oci" ]  || \
+       [ "$type" = "lxc" ]; then
+	case $name in
+	    dom*)
+		output=$name
+		;;
+	    *)
+		output=$type-$name
+		;;
+	esac
     fi
 
     echo ${output}

--- a/sbin/cubename
+++ b/sbin/cubename
@@ -116,7 +116,19 @@ function extract_container_name
 	esac
     fi
 
-    echo ${output}
+
+    if [ -n "${output}" ]; then
+        echo ${output}
+        return 0
+    else
+        return 1
+    fi
 }
 
 extract_container_name $1
+if [ $? -eq 0 ] ; then
+    exit 0
+else
+    echo "ERROR: Could not determine container name" >&2
+    exit 1
+fi

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -601,7 +601,7 @@ install_grub()
     chroot ${mountpoint} /bin/bash -c "mount -t sysfs sys /sys"
 
     if [ -n "$loop_device" ]; then
-	chroot ${mountpoint} /bin/bash -c "${CMD_GRUB_INSTALL} --target=i386-pc --force --boot-directory=/mnt --modules=\" boot linux ext2 fat serial part_msdos part_gpt normal iso9660 search\" /dev/${device}"
+	chroot ${mountpoint} /bin/bash -c "${CMD_GRUB_INSTALL} --target=i386-pc --force --boot-directory=/mnt --modules=\" boot linux ext2 fat serial part_msdos part_gpt normal iso9660 search chain\" /dev/${device}"
     else
 	chroot ${mountpoint} /bin/bash -c "${CMD_GRUB_INSTALL} --target=i386-pc --boot-directory=/mnt --force /dev/${device}"
     fi


### PR DESCRIPTION
Explicitly add the chain module in the list of modules used by GRUB2.  This is needed for the chainloader command used during EFI boot.

Also, replace grepping for INITIAL_PASSWD with just sourcing the variable.   This allows one to use command substitution to crypt the password in the configuration file.  A side effect of this change is that initial_passwd: line will no longer present in the ansible yaml file if the initial_passwd is not set.