### PR TITLE
overc-ctl: set metadata as expired before running check-update

### DIFF
--- a/sbin/overc-ctl
+++ b/sbin/overc-ctl
@@ -220,7 +220,7 @@ run_container_command() {
 rpm_check_update() {
     local container=$1
 
-    run_container_command $container "dnf -q check-update"
+    run_container_command $container "dnf -q check-update --refresh"
 }
 
 rpm_upgrade() {


### PR DESCRIPTION
This is needed or else dnf will not try to pull the latest updates.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>