### PR TITLE
chvt.service: add --echo option to cube-cmd

### DIFF
--- a/files/chvt.service
+++ b/files/chvt.service
@@ -3,7 +3,7 @@ Description=Change the %OVERC_ACTIVE_VT% to be the active vt
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/cube-cmd cube-cmd chvt %OVERC_ACTIVE_VT%
+ExecStart=/usr/sbin/cube-cmd --echo cube-cmd chvt %OVERC_ACTIVE_VT%
 #StandardInput=tty
 #TTYPath=/dev/tty%OVERC_ACTIVE_VT%
 #TTYReset=yes


### PR DESCRIPTION
This fixes a tty device missing problem when cube-cmd is executed by
systemd.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>