### PR TITLE
overc-ctl: do not reboot after rolling back container if upgrading fails

### DIFF
--- a/sbin/overc-ctl
+++ b/sbin/overc-ctl
@@ -443,7 +443,7 @@ upgrade_container() {
     create_snapshot || return 1
     if ! eval ${package_manager}_upgrade "${container_name}"; then
         log_error "Upgrade container with ${package_manager} failed, rollback to the latest"
-        rollback_container "true" "true"
+        rollback_container "true" ""
         return 1
     fi
 


### PR DESCRIPTION
Considering that there could be multiple containers doing upgrading in
a row, once one of them fails, it would rollback to the previous stable
snapshot, which is no problem, but it does not have to reboot after
that, because the containers(including dom0) should have consistent
behavior, like if dom0 fails to upgrade, it would roll back but will not
reboot, overc will print a error message to the console, the end users
hence and decide what to do.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>