### PR TITLE
overc-installer: prepare the firmware for essential

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -1108,6 +1108,13 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	    ${f}
 	done
     fi
+
+    #prepare the firmwares in essential
+    if [ ! -d ${TMPMNT}/var/lib/cube/essential/lib/firmware ]; then
+        mkdir -p ${TMPMNT}/var/lib/cube/essential/lib/firmware
+    fi
+    cp -a ${TMPMNT}/opt/container/dom0/rootfs/lib/firmware/* ${TMPMNT}/var/lib/cube/essential/lib/firmware
+    
     sync
     umount ${TMPMNT}/opt/container
 


### PR DESCRIPTION
It's better to prepare the firmware for essential
in installer instead in the dom0's first boot.
Thus it will avoiding the issue of can't find the
proper firmwares in essential when it first boot.

Signed-off-by: Fupan Li <fupan.li@windriver.com>