### PR TITLE
overc-ctl: change the track_container behavior

### DIFF
--- a/sbin/overc-ctl
+++ b/sbin/overc-ctl
@@ -289,28 +289,23 @@ switch_to_snapshot() {
 # Command functions
 #
 track_container() {
-    if [ -n "$(cat ${snapshots_dir}/${container_name}/.container_history 2>/dev/null)" ]; then
-        log_error "container is already tracked"
+    if is_container_available; then
+        log_error "container ${container_name} is already tracked"
         return 1
     fi
 
-    if [ "$(realpath ${container_dir})" != "/opt/container" ]; then
-        # wre might be called by installer, create container subdirectories according
-        # to the fstype of container_dir's mount point:
-        # a) create a subvolume if the fstype is btrfs
-        # b) create a subdirectory for other fstypes
-        local fstype=$(get_mount_fstype "${container_dir}")
-        local subvol_dir=${container_dir}/${container_name}
-        mkdir -p ${subvol_dir%/*}
-        [ -e $subvol_dir ] && rm -rf $subvol_dir
-        if [ "${fstype}" = "btrfs" ]; then
-            btrfs_subvolume_create ${subvol_dir}
-        else
-            mkdir -m 755 ${subvol_dir}
-        fi
+    # Create container subdirectories according to the fstype of container_dir's
+    # mount point:
+    # a) create a subvolume if the fstype is btrfs
+    # b) create a subdirectory for other fstypes
+    local fstype=$(get_mount_fstype "${container_dir}")
+    local subvol_dir=${container_dir}/${container_name}
+    mkdir -p ${subvol_dir%/*}
+    [ -e $subvol_dir ] && rm -rf $subvol_dir
+    if [ "${fstype}" = "btrfs" ]; then
+        btrfs_subvolume_create ${subvol_dir}
     else
-        # we are at runtime, create a snapshot of container
-        create_snapshot ${container_name}
+        mkdir -m 755 ${subvol_dir}
     fi
 }
 


### PR DESCRIPTION
If the track_container is being called on target by users, it should
really track a container rather than creating a snapshot, this allows
the users to create snapshots to the newly added containers, or else
there is no way to create a container on a subvolume.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>