### PR TITLE
cubeit-installer: drop --track option

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -867,10 +867,10 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 
 	case $container_src in
 	    *-dom0-*)
-		${SBINDIR}/cube-ctl add --track --auto essential -n ${cname} -t cube -o ${CONTAINERBASE} ${c}
+		${SBINDIR}/cube-ctl add --auto essential -n ${cname} -t cube -o ${CONTAINERBASE} ${c}
 		;;
 	    *)
-		${SBINDIR}/cube-ctl add --track --auto dom0 -n ${cname} -t oci -o ${CONTAINERBASE} ${c}
+		${SBINDIR}/cube-ctl add --auto dom0 -n ${cname} -t oci -o ${CONTAINERBASE} ${c}
 		;;
 	esac
 


### PR DESCRIPTION
All containers will be tracked by default, which ensures they could be
snapshotted, rolled back and so on.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>