### PR TITLE
Update for customizing partition on target

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -133,6 +133,10 @@ while [ $# -gt 0 ]; do
             FDISK_PARTITION_LAYOUT_INPUT="$2"
             shift
             ;;
+    --container_partition)
+            CONTAINER_PARTITION="$2"
+            shift
+            ;;
     --encrypt)
             do_encryption=1
             ;;
@@ -446,7 +450,12 @@ mkfs.vfat -I -n $BOOTLABEL /dev/${fs_dev}1
 
 ## define the device file names for rootfs and container filesystem
 rootfs_dev=${fs_dev}3
-container_fs_dev=${fs_dev}4
+
+if [ -n "${CONTAINER_PARTITION}" ]; then
+	container_fs_dev=${fs_dev}${CONTAINER_PARTITION}
+else
+	container_fs_dev=${fs_dev}4
+fi
 
 if [ $do_encryption -eq 1 ]; then
     ## Evict all objects for the first creation.

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -604,6 +604,24 @@ custom_install_rules()
 		return 1
 	fi
 
+	# Copy partition_layout file to ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR} if it is specified,
+	# so that the partition file could be packaged into the installer image
+	if [ -n ${FDISK_PARTITION_LAYOUT_INPUT} ]; then
+		if [ ! -e ${FDISK_PARTITION_LAYOUT_INPUT} ]; then
+			debugmsg ${DEBUG_CRIT} "ERROR: Failed to locate partition file"
+			return 1
+		fi
+
+		recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}
+		assert_return $?
+		
+		cp -f "${FDISK_PARTITION_LAYOUT_INPUT}" ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}
+		if [ $? -ne 0 ]; then
+			debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy partition file"
+			return 1
+		fi
+	fi
+
 	recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_INSTALLERS_DIR}
 	assert_return $?
 


### PR DESCRIPTION
1. Bug fix for passing --partition_layout
2. Add a new argument for specifying which partition is used for installing container rootfs.

So that users can customize their own partition layout and specify a particular partition to install container rootfs:

installer/cubeit-installer --partition_layout new-partition.txt --container_partition N -b images/cube=* /dev/sdX