### PR TITLE
Work around multiple grub targets

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -611,7 +611,30 @@ if ${X86_ARCH}; then
     chroot ${TMPMNT} /bin/bash -c "mount -t proc proc /proc"
     chroot ${TMPMNT} /bin/bash -c "mount -t sysfs sys /sys"
 
-    grub_target=$(ls ${TMPMNT}/usr/lib*/grub/)
+    grub_target=$(ls ${TMPMNT}/usr/lib*/grub/ | tr '\n' ' ')
+    num_grub_targets=$(echo $grub_target | wc -w)
+    if [ $num_grub_targets -eq 1 ]; then
+	if [ "$grub_target" != "$GRUB_TARGET" ]; then
+	    debugmsg ${DEBUG_INFO} "[INFO]: Ignoring GRUB_TARGET ($GRUB_TARGET not found). Using $grub_target."
+	fi
+    else
+	if [ -z "$GRUB_TARGET" ]; then
+	    gt=$(echo $grub_target | awk '{print $1;}')
+	    debugmsg ${DEBUG_INFO} "[INFO]: Multiple grub targets available ($grub_target). Using $gt."
+	    debugmsg ${DEBUG_INFO} "[INFO]: Overwrite default selection by setting GRUB_TARGET."
+	    grub_target=$gt
+	else
+	    $(echo $grub_target | grep -qE "(^| )$GRUB_TARGET( |$)")
+	    if [ $? -ne 0 ]; then
+		gt=$(echo $grub_target | awk '{print $1;}')
+		debugmsg ${DEBUG_INFO} "[INFO]: Ignoring GRUB_TARGET ($GRUB_TARGET not found). Using $gt."
+		debugmsg ${DEBUG_INFO} "[INFO]: Set GRUB_TARGET to one of ($grub_target) to overwrite."
+		grub_target=$gt
+	    else
+		grub_target=$GRUB_TARGET
+	    fi
+	fi
+    fi
     echo "$grub_target" | grep -q "efi"
     if [ $? -eq 0 ]; then
 	efi=t

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -606,8 +606,8 @@ custom_install_rules()
 
 	# Copy partition_layout file to ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR} if it is specified,
 	# so that the partition file could be packaged into the installer image
-	if [ -n ${FDISK_PARTITION_LAYOUT_INPUT} ]; then
-		if [ ! -e ${FDISK_PARTITION_LAYOUT_INPUT} ]; then
+	if [ -n "${PARTITION_LAYOUT_INPUT}" ]; then
+		if [ ! -e ${PARTITION_LAYOUT_INPUT} ]; then
 			debugmsg ${DEBUG_CRIT} "ERROR: Failed to locate partition file"
 			return 1
 		fi
@@ -615,7 +615,7 @@ custom_install_rules()
 		recursive_mkdir ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}
 		assert_return $?
 		
-		cp -f "${FDISK_PARTITION_LAYOUT_INPUT}" ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}
+		cp -f "${PARTITION_LAYOUT_INPUT}" ${mnt_rootfs}${INSTALLER_TARGET_CONFIG_DIR}
 		if [ $? -ne 0 ]; then
 			debugmsg ${DEBUG_CRIT} "ERROR: Failed to copy partition file"
 			return 1


### PR DESCRIPTION
Apparently not all builds produce a grub with a single target. When there are multiple targets available the logic to determine the grub_target falls over. Add logic to work with multiple available targets. As with most things we will always default to something and complete the install. If the user is not happy with the default they can set GRUB_TARGET to overwrite things.

The first commit is lifted from @yunguowei 's original pull request. The second commit expands on @yunguowei 's original effort to work around the multiple targets issue.