### PR TITLE
[V2] cubeit: implement the 'mounts' container attribute

### DIFF
--- a/config/config-usb-cube.sh.sample
+++ b/config/config-usb-cube.sh.sample
@@ -2,6 +2,15 @@ source config-usb.sh
 
 HDINSTALL_ROOTFS="${ARTIFACTS_DIR}/cube-essential-genericx86-64.tar.bz2"
 
+# Container attributes:
+#   mounts=type|src|dst;type|src|dst... (see 'c3 cfg mount')
+#   net=X (if X==1 the container will be the netprime, static IPs should us X>4)
+#   cube.device.mgr=self (allow container access devices directly)
+#   vty=X (where X>2) (place container console on specified virtual terminal)
+#   mergepath=<path>,<container,[container]>
+#   subuid=XXXX (specify unprivileged subuid/subgid)
+#   console (container gets a virtual console)
+#   hardconsole (container gets a physical console)
 HDINSTALL_CONTAINERS="${ARTIFACTS_DIR}/cube-dom0-genericx86-64.tar.bz2:vty=2:mergepath=/usr,essential \
                       ${ARTIFACTS_DIR}/cube-dom1-genericx86-64.tar.bz2:vty=3:mergepath=/usr,essential,dom0 \
                       ${ARTIFACTS_DIR}/cube-desktop-genericx86-64.tar.bz2:vty=4:net=1:mergepath=/usr,essential,dom0,dom1 \

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -882,6 +882,14 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	    )
 	fi
 
+	# Configure container mounts
+	mounts=`get_prop_value_by_container $cname "mounts"`
+	if [ -n "$mounts" ]; then
+	    for mount in $(echo $mounts | tr '|' ':' | tr ';' '\n'); do
+		${SBINDIR}/cube-cfg -o ${TMPMNT}/opt/container/${cname} mount $mount
+	    done
+	fi
+
 	# TTY/console processing
 	# Any container that has a console attribute gets a virtual console
 	consoleattr=`get_prop_isset_by_container $cname "console"`

--- a/sbin/cubeit
+++ b/sbin/cubeit
@@ -531,7 +531,7 @@ install_summary()
     echo "             $package_count packages available from: ${PACKAGES_DIR}"
     echo "   containers: "
     for i in ${HDINSTALL_CONTAINERS}; do
-        echo "             `basename ${i}`"
+        echo "             $(basename $(echo ${i} | cut -d':' -f1))"
     done
     echo ""
 


### PR DESCRIPTION
**V2**
s/mount/mounts/
***

It is sometimes desirable to be able to configure mounts before the
first boot of a device so implement a 'mounts' container attribute to
allow this to be configured.

The syntax matches 'c3 cfg mount' and makes use of this functionality
directly. Since the mount is defined using a path (/blah/this/that)
this new attribute exposed a flaw in how we displayed the container
tarball names in the "Install Summary" so we fixed this by ensuring we
pass the first field (the container path) to basename. We also add a
list of attributes and a quick summary of each to the installer
configuration sample.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>