### PR TITLE
cubeit-installer: copy EFI boot artifacts on x86 platform

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -660,6 +660,12 @@ if ${X86_ARCH}; then
 
     debugmsg ${DEBUG_INFO} "[INFO]: grub installed"
 
+    if [ -f ${TMPMNT}/boot/efi/EFI/BOOT/boot*.efi ]; then
+        debugmsg ${DEBUG_INFO} "[INFO]: installing EFI artifacts"
+        mkdir -p ${TMPMNT}/mnt/EFI/BOOT
+	cp -a ${TMPMNT}/boot/efi/EFI ${TMPMNT}/mnt
+    fi
+
 else # arm architecture
     if [ -e "${INSTALL_DTB}" ]; then
         install_dtb "${TMPMNT}/mnt" "${INSTALL_DTB}"


### PR DESCRIPTION
Those boot artifacts are used during UEFI secure boot, so make sure they
are completely deployed in efi system partition.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>