### PR TITLE
cubeit-installer: Add in the cube.admin attribute

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -826,6 +826,10 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	container_src=`basename $c`
 	cname=`${SBINDIR}/cubename $CNAME_PREFIX $c`
 
+	cubeadmin=`get_prop_value_by_container ${cname} "cube.admin"`
+	if [ "${cubeadmin}" = "1" ] ; then
+		${SBINDIR}/cube-cfg -o ${TMPMNT}/opt/container/${cname} hook-script prestart:/usr/libexec/cube/hooks.d/cube-admin up \$\(cat\)
+	fi
 	devicemgr=`get_prop_value_by_container ${cname} "cube.device.mgr"`
 	if [ "${devicemgr}" = "self" ]; then
 	    (


### PR DESCRIPTION
The cube.admin attribute for the installer will allow a container to
be deployed with the admin tools hook at install time.

Example:

HDINSTALL_CONTAINERS=" \
    ${ARTIFACTS_DIR}/cube-desktop-intel-corei7-64.tar.bz2:console:vty=3:net=1:cube.device.mgr=self:cube.admin=1 \
"

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>