### PR TITLE
V2 of network offset plus a small fix

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -21,6 +21,8 @@ BASEDIR=$(readlink -f $(dirname $BASH_SOURCE))
 IMAGESDIR="${BASEDIR}/../images"
 CONTAINERSDIR="${BASEDIR}/../images/containers"
 PACKAGESDIR="${BASEDIR}/../packages"
+NET_OFFSET_MIN=11
+NET_OFFSET_MAX=100
 SBINDIR="${BASEDIR}/../sbin"
 LIBDIR="${BASEDIR}/../lib"
 export SBINDIR
@@ -731,10 +733,6 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
         mount -o subvol=workdir /dev/${container_fs_dev} ${TMPMNT}/opt/container
     fi
 
-    # deal with static IPs and the "Networking Prime"
-    network_offsets=()
-    network_container=()
-
     CNRECORD=`mktemp /tmp/hdcontainerXXXXX`
     export CNRECORD
 
@@ -755,20 +753,16 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	cp $c ${TMPMNT}/tmp/
 	cp ${SBINDIR}/cube-ctl ${TMPMNT}/tmp/
 
-	# If a net offset is specified for this container add
-	# it to the network_offsets list in the overc_config_vars.yml
-	# in order to have ansible configure the container.
-	# An offset of '1' will make that container the
-	# "network prime".
+	# Identify the Network Prime and VRF containers by their 'net'
+	# offset attribute. An offset of '1' will make that container
+	# the "network prime". The VRF container will have its 'net' offset
+	# set to 'vrf'.
 	net_offset=`get_prop_value_by_container $cname "net"`
 	if [ -n "$net_offset" ]; then
 	    if [ "$net_offset" = "1" ] || [ "$net_offset" = "prime" ]; then
 		network_prime="$cname"
 	    elif [ "$net_offset" = "vrf" ]; then
 		network_vrf="$cname"
-	    else
-		network_offsets+=("'$net_offset'")
-		network_container+=("'$cname'")
 	    fi
 	fi
 
@@ -846,6 +840,26 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	    for mount in $(echo $mounts | tr '|' ':' | tr ';' '\n'); do
 		${SBINDIR}/cube-cfg -o ${TMPMNT}/opt/container/${cname} mount $mount
 	    done
+	fi
+
+	# Configure network offset
+	net_offset=`get_prop_value_by_container $cname "net"`
+	if [ -n "$net_offset" ] && [ "$net_offset" != "1" ]; then
+	    case "$cname" in
+	    dom0|${network_vrf})
+		# Special handling (search this file for "static")
+		;;
+	    *)
+		if [ ${net_offset} -lt ${NET_OFFSET_MIN} ] || [ ${net_offset} -gt ${NET_OFFSET_MAX} ]; then
+		    debugmsg ${DEBUG_CRIT} "[ERROR]: Ignoring network offset of ${net_offset} for ${cname}. " \
+						"Must be >=${NET_OFFSET_MIN} and <=${NET_OFFSET_MAX}."
+		else
+		    echo "[INFO]: Setting a static network offset of ${net_offset} for ${cname}"
+		    ${SBINDIR}/cube-cfg -o ${TMPMNT}/opt/container/${cname} set cube.network.ip:192.168.42.${net_offset}/24
+		    ${SBINDIR}/cube-cfg -o ${TMPMNT}/opt/container/${cname} set cube.network.type:static
+		fi
+		;;
+	    esac
 	fi
 
 	# TTY/console processing

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -591,7 +591,6 @@ if [ $btrfs -eq 1 ]; then
 
 	cd /
 	sync
-	umount ${TMPMNT}/rootfs/mnt
 	umount ${TMPMNT}/
 	mount -o subvolid=${subvol} /dev/${rootfs_dev} ${TMPMNT}
 	cd ${TMPMNT}/


### PR DESCRIPTION
V2 of the network offset fixup. V2 differs from V1 in a few ways:

- Address Bruce's comment to check on the offset range. I am going with 11-100 (giving 90 static IPs we can use for statics).
- Remove the network_offset and network_container lists that are not used any longer (missed this cleanup in V1)
- Found a bug in V1 with test as number when offset can be a word, fixed this.

The new commit fixes an unmount error seen when running the installer, it was cleanup that was missed by the original change, as indicated in the commit long log.