### PR TITLE
Handle race condition between partition and filesystem creation steps

### DIFF
--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -1224,6 +1224,8 @@ installer_main()
 		exit 1
 	fi
 
+	sleep 1
+
 	## Create new filesystems
 	debugmsg ${DEBUG_INFO} "Creating new filesystems "
 	if [ -z "$BOOTPART_LABEL" ]; then


### PR DESCRIPTION
Frequently an error was observed during "cubeit" operation

>>>
Creating new partitions
Creating partition sdc1
Creating partition sdc2
Creating new filesystems
Creating Partition:sdc1 Type:fat32 Label:OVERCBOOT
ERROR: Specified partition (sdc1) does not exist
>>>

Adding a 1 second pause between partitioning and filesystem creation fixes
the issue.