### PR TITLE
cubeit-installer: Use netprime name in the netprime setting section

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -1024,11 +1024,11 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 		    if [ -e "pflask.cmd" ]; then
 			${SBINDIR}/cube-cfg hook-script poststart:/usr/libexec/cube/hooks.d/cube-netconfig netprime
 			${SBINDIR}/cube-cfg gen ${network_prime}:cube
-			service_disable systemd-resolved.service ${cname}
+			service_disable systemd-resolved.service ${network_prime}
 		    else
 			${SBINDIR}/cube-cfg hook-script poststart:/usr/libexec/cube/hooks.d/cube-netconfig netprime \$\(cat\)
 			${SBINDIR}/cube-cfg gen ${network_prime}:oci
-			service_disable systemd-resolved.service ${cname}
+			service_disable systemd-resolved.service ${network_prime}
 		    fi
 		)
 	    fi


### PR DESCRIPTION
Depending on what ever container runs last for the
HDD_INSTALL_CONTAINERS it will stay set as the cname in the netprime
section.  If the cube-vrf was installed last, it will partially get
treated like the netprime and the real netprime will not get the
system-resolved service turned off.  The simple fix is to just use the
correct variable.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>