### PR TITLE
V2: cubeit: Add the 'app' container attribute

### DIFF
--- a/config/config-usb-cube.sh.sample
+++ b/config/config-usb-cube.sh.sample
@@ -6,6 +6,7 @@ HDINSTALL_ROOTFS="${ARTIFACTS_DIR}/cube-essential-genericx86-64.tar.bz2"
 #   mounts=type|src|dst;type|src|dst... (see 'c3 cfg mount')
 #   net=X (if X==1 the container will be the netprime, static IPs should us X>4
 #          use X==vrf for the cube-vrf)
+#   app=<app>,[arg],... (used to overwrite default app, /sbin/init, and args)
 #   cube.device.mgr=self (allow container access devices directly)
 #   vty=X (where X>2) (place container console on specified virtual terminal)
 #   mergepath=<path>,<container,[container]>
@@ -13,7 +14,7 @@ HDINSTALL_ROOTFS="${ARTIFACTS_DIR}/cube-essential-genericx86-64.tar.bz2"
 #   console (container gets a virtual console)
 #   hardconsole (container gets a physical console)
 HDINSTALL_CONTAINERS="${ARTIFACTS_DIR}/cube-dom0-genericx86-64.tar.bz2:vty=2:mergepath=/usr,essential \
-                      ${ARTIFACTS_DIR}/cube-vrf-genericx86-64.tar.bz2:net=vrf \
+                      ${ARTIFACTS_DIR}/cube-vrf-genericx86-64.tar.bz2:net=vrf:app=/usr/bin/docker-init,/sbin/vrf-init \
                       ${ARTIFACTS_DIR}/cube-desktop-genericx86-64.tar.bz2:vty=3:net=1:mergepath=/usr,essential,dom0 \
                       ${ARTIFACTS_DIR}/cube-server-genericx86-64.tar.bz2:subuid=800000"
 

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -833,6 +833,14 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	    )
 	fi
 
+	# Configure container 'app' (ie. process.args). By default this will
+	# be /sbin/init but at times we need to overwrite this, for example
+	# when we use tini 'init' as we do for the cube-vrf.
+	app=`get_prop_value_by_container $cname "app"`
+	if [ -n "$app" ]; then
+	    ${SBINDIR}/cube-cfg -o ${TMPMNT}/opt/container/${cname} set app:$(echo $app | tr ',' ' ')
+	fi
+
 	# Configure container mounts
 	mounts=`get_prop_value_by_container $cname "mounts"`
 	if [ -n "$mounts" ]; then


### PR DESCRIPTION
Up to now we have always used the default 'app' for our containers,
that being '/sbin/init'. Now we want to use tini for the cube-vrf and
possibly for other microservice containers in the future, which
requires that we pass args or possibly even use an app which is
different than '/sbin/init'. We therefor add a new 'app' attribute
which can be specified per container.

----
V2: Unfortunately we couldn't make use of the /sbin/init link for tini and instead we need to reference the tini executable