### PR TITLE
cubeit-installer: keep systemd-getty-generator under control

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -645,6 +645,10 @@ if [ "${SCREEN_GETTY_CONSOLE}" != "" ] ; then
     con=${SCREEN_GETTY_CONSOLE%,*}
     baud=${SCREEN_GETTY_CONSOLE#*,}
     systemd_getty=/lib/systemd/system/screen-getty@.service
+
+    # Prevent systemd-getty-generator from creating the serial getty
+    ln -sf /dev/null ${TMPMNT}/etc/systemd/system/serial-getty@$con.service
+
     if [ "${baud}" != "" -a "${baud}" != "115200" ] ; then
 	cp ${TMPMNT}/lib/systemd/system/screen-getty@.service ${TMPMNT}/lib/systemd/system/screen-getty-$baud@.service
 	perl -p -i -e "s/(screen-getty \%I) .*? /\$1 $baud /" ${TMPMNT}/lib/systemd/system/screen-getty@.service


### PR DESCRIPTION
The systemd-getty-generator will interpret the kernel cmdline
"console" to create serial-getty@XXX.service files automatically. This
will result in a battle between the screen and serial gettys and thus
an unusable terminal. By creating a link for the interface we know we
want to use with screen, ie. SCREEN_GETTY_CONSOLE%, to /dev/null we
effective stop systemd-getty-generator from creating the serial-getty
and messing things up.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>