### PR TITLE
functions.sh: Fix grub-install to work with grub 2.04

### DIFF
--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -739,7 +739,7 @@ install_grub()
 	    if [ $? -eq 0 ]; then
 		efi=t
 		g_efi=${g_check}
-		chroot ${mountpoint} /bin/bash -c "${CMD_GRUB_INSTALL} --target=${g_check} --boot-directory=/mnt --force --removable --efi-directory=/mnt /dev/${device}"
+		chroot ${mountpoint} /bin/bash -c "${CMD_GRUB_INSTALL} --target=${g_check} --boot-directory=/mnt --force --removable --efi-directory=/mnt /dev/${device} --modules='boot linux ext2 fat serial part_msdos part_gpt normal                  efi_gop iso9660 configfile search loadenv test'"
 	    else
 		chroot ${mountpoint} /bin/bash -c "${CMD_GRUB_INSTALL} --target=${g_check} --boot-directory=/mnt --force /dev/${device}"
 	    fi


### PR DESCRIPTION
The grub-efi version 2.04 expects that you will add any modules that
you might have run grub-mkimage with if using a Yocto Project build.

The arguments added to the efi version of the grub-install are the
same found in the grub-efi recipe.  This will eliminate the problem of
grub-efi printing a message that it is operating in "blind boot" mode
while trying to start the kernel.

The path for using the non-efi grub-install remains unchanged in the
overc installer because no additional modules are needed to start the
system.

[ Issue: LIN1019-2962 ]

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>