### PR TITLE
cube-installer: deploy Image on ARM64 boards

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -543,6 +543,10 @@ elif ls boot/fitImage-* >/dev/null 2>&1; then
 	cp boot/fitImage-* ${BOOTTMPMNT}/mnt/fitImage
 	#create a backup kernel for recovery boot
 	cp boot/fitImage-* ${BOOTTMPMNT}/mnt/fitImage_bakup
+elif ls boot/Image-* >/dev/null 2>&1; then
+	cp boot/Image-* ${BOOTTMPMNT}/mnt/Image
+	#create a backup kernel for recovery boot
+	cp boot/Image-* ${BOOTTMPMNT}/mnt/Image_bakup
 fi
  
 ## Process initrd into /boot


### PR DESCRIPTION
Usually we build Image for ARM64 boards and use 'booti' to boot kernel
image, so we need to install it appropriately.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>